### PR TITLE
feat: Magic link auth and Supabase callback route

### DIFF
--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+export default function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const searchParams = useSearchParams();
+  const supabase = createClient();
+
+  useEffect(() => {
+    if (searchParams.get("error") === "auth_failed") {
+      setError("Sign-in link expired or already used. Please request a new one.");
+    }
+  }, [searchParams]);
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      setError(error.message);
+      setLoading(false);
+      return;
+    }
+
+    setSubmitted(true);
+    setLoading(false);
+  }
+
+  if (submitted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center space-y-4 max-w-sm">
+          <div className="w-12 h-12 rounded-full bg-brand-red/10 flex items-center justify-center mx-auto">
+            <svg
+              className="w-6 h-6 text-brand-red"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2 2v10a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <h2 className="text-xl font-semibold text-white">Check your email</h2>
+          <p className="text-slate-400 text-sm">
+            We sent a magic link to{" "}
+            <span className="text-white font-medium">{email}</span>. Click it to
+            sign in.
+          </p>
+          <button
+            onClick={() => setSubmitted(false)}
+            className="text-sm text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            Use a different email
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="text-center space-y-2">
+          <div className="flex items-center justify-center gap-3">
+            <span className="text-3xl font-bold text-white">Doly</span>
+            <span className="text-xs font-semibold tracking-widest text-brand-red uppercase px-2 py-1 border border-brand-red rounded">
+              Dentons
+            </span>
+          </div>
+          <p className="text-slate-500 text-sm">Sign in to your account</p>
+        </div>
+
+        <form onSubmit={handleLogin} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-slate-300 mb-1.5"
+            >
+              Email address
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@dentons.com"
+              required
+              className="w-full px-4 py-2.5 rounded-lg bg-navy-50 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-brand-red focus:ring-1 focus:ring-brand-red transition-colors"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-400 bg-red-400/10 px-3 py-2 rounded-lg">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || !email}
+            className="w-full py-2.5 px-4 bg-brand-red text-white font-medium rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? "Sending link..." : "Send magic link"}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-slate-600">
+          A sign-in link will be sent to your email. No password required.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import LoginForm from "./login-form";
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/dashboard";
+
+  if (code) {
+    const supabase = createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // Auth failed — redirect to login with error param
+  return NextResponse.redirect(`${origin}/login?error=auth_failed`);
+}


### PR DESCRIPTION
## Closes

Closes #3

---

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Refactor (no behaviour change)
- [ ] Seed data / migration
- [ ] Config / tooling

---

## Summary

Adds the login page (magic link via Supabase OTP) and the auth callback route. The login form handles the full flow: email input, OTP request, post-submit confirmation state, and expired link error handling. The callback route exchanges the OTP code for a session and redirects to /dashboard. Middleware from the previous PR guards all protected routes automatically.

---

## How to Test

1. Run npm run dev
2. Navigate to /dashboard — should redirect to /login
3. Enter your email and click Send magic link — should show confirmation screen
4. Click the link in your email — should land on /dashboard
5. Refresh /dashboard — should stay logged in (session persists)
6. Try an expired link — should redirect to /login?error=auth_failed with error message shown

---

## Demo Impact

- [ ] Yes
- [x] No — auth scaffolding, not part of the demo flow

---

## Pre-Merge Checklist

- [x] Linked issue number filled in above
- [x] No console.log left in production code
- [x] Supabase Auth OTP enabled in Supabase dashboard (Authentication > Providers > Email)
- [x] Tested locally with npm run build — clean output, /login and /auth/callback both listed