### PR TITLE
feat: Apply official Dentons brand colors

### DIFF
--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -43,11 +43,11 @@ export default function LoginForm() {
 
   if (submitted) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-screen flex items-center justify-center bg-white">
         <div className="text-center space-y-4 max-w-sm">
-          <div className="w-12 h-12 rounded-full bg-brand-red/10 flex items-center justify-center mx-auto">
+          <div className="w-12 h-12 rounded-full bg-brand-purple/10 flex items-center justify-center mx-auto">
             <svg
-              className="w-6 h-6 text-brand-red"
+              className="w-6 h-6 text-brand-purple"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -56,19 +56,19 @@ export default function LoginForm() {
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 strokeWidth={2}
-                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2 2v10a2 2 0 002 2z"
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
               />
             </svg>
           </div>
-          <h2 className="text-xl font-semibold text-white">Check your email</h2>
-          <p className="text-slate-400 text-sm">
+          <h2 className="text-xl font-semibold text-gray-900">Check your email</h2>
+          <p className="text-gray-500 text-sm">
             We sent a magic link to{" "}
-            <span className="text-white font-medium">{email}</span>. Click it to
-            sign in.
+            <span className="text-gray-900 font-medium">{email}</span>. Click it
+            to sign in.
           </p>
           <button
             onClick={() => setSubmitted(false)}
-            className="text-sm text-slate-500 hover:text-slate-300 transition-colors"
+            className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
           >
             Use a different email
           </button>
@@ -78,23 +78,25 @@ export default function LoginForm() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-screen flex items-center justify-center bg-white">
       <div className="w-full max-w-sm space-y-8">
+        {/* Logo */}
         <div className="text-center space-y-2">
           <div className="flex items-center justify-center gap-3">
-            <span className="text-3xl font-bold text-white">Doly</span>
-            <span className="text-xs font-semibold tracking-widest text-brand-red uppercase px-2 py-1 border border-brand-red rounded">
+            <span className="text-3xl font-bold text-gray-900">Doly</span>
+            <span className="text-xs font-semibold tracking-widest text-brand-purple uppercase px-2 py-1 border border-brand-purple rounded">
               Dentons
             </span>
           </div>
-          <p className="text-slate-500 text-sm">Sign in to your account</p>
+          <p className="text-gray-500 text-sm">Sign in to your account</p>
         </div>
 
+        {/* Form */}
         <form onSubmit={handleLogin} className="space-y-4">
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-slate-300 mb-1.5"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
             >
               Email address
             </label>
@@ -105,12 +107,12 @@ export default function LoginForm() {
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@dentons.com"
               required
-              className="w-full px-4 py-2.5 rounded-lg bg-navy-50 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-brand-red focus:ring-1 focus:ring-brand-red transition-colors"
+              className="w-full px-4 py-2.5 rounded-lg bg-white border border-brand-grey text-gray-900 placeholder-gray-400 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
             />
           </div>
 
           {error && (
-            <p className="text-sm text-red-400 bg-red-400/10 px-3 py-2 rounded-lg">
+            <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">
               {error}
             </p>
           )}
@@ -118,13 +120,13 @@ export default function LoginForm() {
           <button
             type="submit"
             disabled={loading || !email}
-            className="w-full py-2.5 px-4 bg-brand-red text-white font-medium rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="w-full py-2.5 px-4 bg-brand-purple text-white font-medium rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {loading ? "Sending link..." : "Send magic link"}
           </button>
         </form>
 
-        <p className="text-center text-xs text-slate-600">
+        <p className="text-center text-xs text-gray-400">
           A sign-in link will be sent to your email. No password required.
         </p>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,16 +3,17 @@
 @tailwind utilities;
 
 :root {
-  --navy: #0F1923;
-  --navy-light: #1a2d3d;
-  --red: #CC0000;
-  --cream: #FBE5D6;
-  --cream-light: #fdf0e8;
+  --purple: #702082;
+  --purple-dark: #5a1a6a;
+  --purple-light: #8b35a0;
+  --white: #ffffff;
+  --grey: #D3D3D3;
+  --grey-bg: #f5f5f5;
 }
 
 body {
-  background-color: var(--navy);
-  color: #f1f5f9;
+  background-color: var(--grey-bg);
+  color: #1a1a1a;
 }
 
 @layer utilities {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,24 @@
 export default function Home() {
   return (
-    <main className="min-h-screen flex items-center justify-center">
+    <main className="min-h-screen flex items-center justify-center bg-white">
       <div className="text-center space-y-4">
         <div className="flex items-center justify-center gap-3 mb-8">
-          <span className="text-4xl font-bold text-white">Doly</span>
-          <span className="text-xs font-semibold tracking-widest text-brand-red uppercase px-2 py-1 border border-brand-red rounded">
+          <span className="text-4xl font-bold text-gray-900">Doly</span>
+          <span className="text-xs font-semibold tracking-widest uppercase px-2 py-1 border border-brand-purple text-brand-purple rounded">
             Dentons
           </span>
         </div>
-        <h1 className="text-2xl font-semibold text-slate-300">
+        <h1 className="text-2xl font-semibold text-gray-700">
           One firm. Everywhere.
         </h1>
-        <p className="text-slate-500 max-w-md mx-auto">
+        <p className="text-gray-500 max-w-md mx-auto">
           Connecting 12,000 lawyers across 80+ countries into one seamless,
           intelligent network.
         </p>
         <div className="pt-6">
           <a
             href="/dashboard"
-            className="inline-block bg-brand-red text-white px-6 py-3 rounded-lg font-medium hover:bg-red-700 transition-colors"
+            className="inline-block bg-brand-purple text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-purple-dark transition-colors"
           >
             Enter Doly
           </a>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,16 +9,14 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        navy: {
-          DEFAULT: "#0F1923",
-          50: "#1a2d3d",
-          100: "#162433",
-          200: "#0F1923",
-          900: "#080f15",
-        },
         brand: {
-          red: "#CC0000",
-          cream: "#FBE5D6",
+          purple: "#702082",
+          "purple-dark": "#5a1a6a",
+          "purple-light": "#8b35a0",
+          white: "#ffffff",
+          grey: "#D3D3D3",
+          "grey-dark": "#a0a0a0",
+          "grey-bg": "#f5f5f5",
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Closes

Closes #5

---

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Refactor (no behaviour change)
- [ ] Seed data / migration
- [ ] Config / tooling

---

## Summary

Applies the official Dentons brand colors across the UI. Primary purple #702082 replaces the approximate navy/red values. All future UI components should use brand-purple, brand-grey, and white as the base palette.

---

## How to Test

1. Run npm run dev
2. Visit http://localhost:3000 — white background, purple Dentons badge, purple CTA button
3. Visit http://localhost:3000/login — white form, purple focus ring, purple submit button

---

## Demo Impact

- [ ] Yes
- [x] No — visual only, no logic change

---

## Pre-Merge Checklist

- [x] Linked issue number filled in above
- [x] No console.log left in production code
- [x] Tested locally with npm run dev