### PR TITLE
feat: Lawyer directory page

### DIFF
--- a/app/lawyers/_components/LawyersDirectory.tsx
+++ b/app/lawyers/_components/LawyersDirectory.tsx
@@ -63,6 +63,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
           <input
             type="text"
+            aria-label="Search lawyers by name or office"
             placeholder="Search by name or office..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -71,6 +72,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
         </div>
 
         <select
+          aria-label="Filter by jurisdiction"
           value={selectedJurisdiction}
           onChange={(e) => setSelectedJurisdiction(e.target.value)}
           className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
@@ -82,6 +84,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
         </select>
 
         <select
+          aria-label="Filter by language"
           value={selectedLanguage}
           onChange={(e) => setSelectedLanguage(e.target.value)}
           className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
@@ -105,7 +108,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
       {/* Results */}
       {filtered.length === 0 ? (
         <div className="text-center py-16">
-          <p className="text-gray-400 text-sm">No lawyers match your filters.</p>
+          <p className="text-gray-400 text-sm">No lawyers match your search.</p>
           <button
             onClick={clearFilters}
             className="mt-2 text-brand-purple text-sm hover:underline"

--- a/app/lawyers/_components/LawyersDirectory.tsx
+++ b/app/lawyers/_components/LawyersDirectory.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Search } from "lucide-react";
+import LawyerCard, { type LawyerWithJurisdictions } from "@/components/lawyers/LawyerCard";
+
+export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJurisdictions[] }) {
+  const [search, setSearch] = useState("");
+  const [selectedJurisdiction, setSelectedJurisdiction] = useState("");
+  const [selectedLanguage, setSelectedLanguage] = useState("");
+
+  const allJurisdictions = useMemo(() => {
+    const codes = new Set<string>();
+    lawyers.forEach((l) => l.lawyer_jurisdictions.forEach((j) => codes.add(j.jurisdiction_code)));
+    return Array.from(codes).sort();
+  }, [lawyers]);
+
+  const allLanguages = useMemo(() => {
+    const langs = new Set<string>();
+    lawyers.forEach((l) => l.languages.forEach((lang) => langs.add(lang)));
+    return Array.from(langs).sort();
+  }, [lawyers]);
+
+  const filtered = useMemo(() => {
+    return lawyers.filter((l) => {
+      const matchesSearch =
+        !search ||
+        l.full_name.toLowerCase().includes(search.toLowerCase()) ||
+        l.office_city.toLowerCase().includes(search.toLowerCase()) ||
+        l.office_country.toLowerCase().includes(search.toLowerCase());
+
+      const matchesJurisdiction =
+        !selectedJurisdiction ||
+        l.lawyer_jurisdictions.some((j) => j.jurisdiction_code === selectedJurisdiction);
+
+      const matchesLanguage =
+        !selectedLanguage ||
+        l.languages.some((lang) => lang.toLowerCase() === selectedLanguage.toLowerCase());
+
+      return matchesSearch && matchesJurisdiction && matchesLanguage;
+    });
+  }, [lawyers, search, selectedJurisdiction, selectedLanguage]);
+
+  const hasFilters = search || selectedJurisdiction || selectedLanguage;
+
+  function clearFilters() {
+    setSearch("");
+    setSelectedJurisdiction("");
+    setSelectedLanguage("");
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Lawyer Directory</h1>
+        <p className="text-sm text-gray-500 mt-1">{lawyers.length} lawyers across the firm</p>
+      </div>
+
+      {/* Search + filters */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div className="relative flex-1 min-w-[220px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search by name or office..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-4 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+          />
+        </div>
+
+        <select
+          value={selectedJurisdiction}
+          onChange={(e) => setSelectedJurisdiction(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+        >
+          <option value="">All jurisdictions</option>
+          {allJurisdictions.map((j) => (
+            <option key={j} value={j}>{j}</option>
+          ))}
+        </select>
+
+        <select
+          value={selectedLanguage}
+          onChange={(e) => setSelectedLanguage(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+        >
+          <option value="">All languages</option>
+          {allLanguages.map((lang) => (
+            <option key={lang} value={lang}>{lang}</option>
+          ))}
+        </select>
+
+        {hasFilters && (
+          <button
+            onClick={clearFilters}
+            className="px-3 py-2 rounded-lg text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Results */}
+      {filtered.length === 0 ? (
+        <div className="text-center py-16">
+          <p className="text-gray-400 text-sm">No lawyers match your filters.</p>
+          <button
+            onClick={clearFilters}
+            className="mt-2 text-brand-purple text-sm hover:underline"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : (
+        <>
+          {hasFilters && (
+            <p className="text-sm text-gray-400 mb-4">
+              {filtered.length} result{filtered.length !== 1 ? "s" : ""}
+            </p>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map((lawyer) => (
+              <LawyerCard key={lawyer.id} lawyer={lawyer} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/lawyers/page.tsx
+++ b/app/lawyers/page.tsx
@@ -16,7 +16,7 @@ export default async function LawyersPage() {
     .order("reputation_score", { ascending: false });
 
   if (error) {
-    console.error("Failed to load lawyers:", error.message);
+    throw new Error(`Failed to load lawyers: ${error.message}`);
   }
 
   const lawyers = (data ?? []) as unknown as LawyerWithJurisdictions[];

--- a/app/lawyers/page.tsx
+++ b/app/lawyers/page.tsx
@@ -1,8 +1,32 @@
-export default function LawyersPage() {
+import { createClient } from "@/lib/supabase/server";
+import Sidebar from "@/components/layout/Sidebar";
+import LawyersDirectory from "./_components/LawyersDirectory";
+import type { LawyerWithJurisdictions } from "@/components/lawyers/LawyerCard";
+
+export default async function LawyersPage() {
+  const supabase = createClient();
+
+  const { data, error } = await supabase
+    .from("lawyers")
+    .select(`
+      id, full_name, title, office_city, office_country,
+      languages, reputation_score, matters_count, avatar_url,
+      lawyer_jurisdictions(jurisdiction_code, jurisdiction_name, expertise_level)
+    `)
+    .order("reputation_score", { ascending: false });
+
+  if (error) {
+    console.error("Failed to load lawyers:", error.message);
+  }
+
+  const lawyers = (data ?? []) as unknown as LawyerWithJurisdictions[];
+
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold text-white">Lawyers</h1>
-      <p className="text-slate-400 mt-2">Coming soon — Phase 0</p>
+    <div className="flex min-h-screen bg-brand-grey-bg">
+      <Sidebar />
+      <main className="flex-1 p-8">
+        <LawyersDirectory lawyers={lawyers} />
+      </main>
     </div>
   );
 }

--- a/components/lawyers/LawyerCard.tsx
+++ b/components/lawyers/LawyerCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import type { Lawyer, LawyerJurisdiction } from "@/types";
 
 export type LawyerWithJurisdictions = Pick<
@@ -31,10 +32,12 @@ export default function LawyerCard({ lawyer }: { lawyer: LawyerWithJurisdictions
       <div className="flex items-start gap-3 mb-4">
         <div className="w-10 h-10 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
           {lawyer.avatar_url ? (
-            <img
+            <Image
               src={lawyer.avatar_url}
               alt={lawyer.full_name}
-              className="w-10 h-10 rounded-full object-cover"
+              width={40}
+              height={40}
+              className="rounded-full object-cover"
             />
           ) : (
             <span className="text-brand-purple font-semibold text-sm">

--- a/components/lawyers/LawyerCard.tsx
+++ b/components/lawyers/LawyerCard.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import type { Lawyer, LawyerJurisdiction } from "@/types";
+
+export type LawyerWithJurisdictions = Pick<
+  Lawyer,
+  "id" | "full_name" | "title" | "office_city" | "office_country" | "languages" | "reputation_score" | "matters_count" | "avatar_url"
+> & {
+  lawyer_jurisdictions: Pick<LawyerJurisdiction, "jurisdiction_code" | "jurisdiction_name" | "expertise_level">[];
+};
+
+function Initials({ name }: { name: string }) {
+  const parts = name.trim().split(" ");
+  return parts.length >= 2
+    ? `${parts[0][0]}${parts[parts.length - 1][0]}`
+    : name[0];
+}
+
+export default function LawyerCard({ lawyer }: { lawyer: LawyerWithJurisdictions }) {
+  const topJurisdictions = [...lawyer.lawyer_jurisdictions]
+    .sort((a, b) => b.expertise_level - a.expertise_level)
+    .slice(0, 3);
+
+  const extraCount = lawyer.lawyer_jurisdictions.length - 3;
+
+  return (
+    <Link
+      href={`/lawyers/${lawyer.id}`}
+      className="bg-white border border-brand-grey rounded-xl p-5 hover:border-brand-purple hover:shadow-sm transition-all group block"
+    >
+      {/* Avatar + name */}
+      <div className="flex items-start gap-3 mb-4">
+        <div className="w-10 h-10 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
+          {lawyer.avatar_url ? (
+            <img
+              src={lawyer.avatar_url}
+              alt={lawyer.full_name}
+              className="w-10 h-10 rounded-full object-cover"
+            />
+          ) : (
+            <span className="text-brand-purple font-semibold text-sm">
+              <Initials name={lawyer.full_name} />
+            </span>
+          )}
+        </div>
+        <div className="min-w-0">
+          <p className="font-semibold text-gray-900 group-hover:text-brand-purple transition-colors truncate text-sm">
+            {lawyer.full_name}
+          </p>
+          <p className="text-xs text-gray-500 truncate">{lawyer.title}</p>
+          <p className="text-xs text-gray-400 mt-0.5">
+            {lawyer.office_city}, {lawyer.office_country}
+          </p>
+        </div>
+      </div>
+
+      {/* Jurisdiction badges */}
+      {topJurisdictions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {topJurisdictions.map((j) => (
+            <span
+              key={j.jurisdiction_code}
+              className="text-xs px-2 py-0.5 bg-brand-purple/10 text-brand-purple rounded-full border border-brand-purple/20"
+            >
+              {j.jurisdiction_code}
+            </span>
+          ))}
+          {extraCount > 0 && (
+            <span className="text-xs px-2 py-0.5 bg-gray-100 text-gray-400 rounded-full">
+              +{extraCount}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Languages + reputation */}
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-400 truncate">
+          {lawyer.languages.slice(0, 2).join(", ")}
+          {lawyer.languages.length > 2 && ` +${lawyer.languages.length - 2}`}
+        </p>
+        <div className="flex items-center gap-0.5 flex-shrink-0">
+          <span className="text-xs font-semibold text-gray-700">
+            {lawyer.reputation_score.toLocaleString()}
+          </span>
+          <span className="text-xs text-gray-400 ml-0.5">pts</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -19,7 +19,12 @@ export default function Sidebar() {
   const supabase = createClient();
 
   async function handleSignOut() {
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error("Sign-out failed:", error.message);
+      return;
+    }
+    router.refresh();
     router.push("/login");
   }
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { LayoutDashboard, Users, Briefcase, FileText, Award, LogOut } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+
+const navItems = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/lawyers", label: "Lawyers", icon: Users },
+  { href: "/matters", label: "Matters", icon: Briefcase },
+  { href: "/field-notes", label: "Field Notes", icon: FileText },
+  { href: "/reputation", label: "Reputation", icon: Award },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const supabase = createClient();
+
+  async function handleSignOut() {
+    await supabase.auth.signOut();
+    router.push("/login");
+  }
+
+  return (
+    <aside className="w-60 min-h-screen bg-brand-purple flex flex-col flex-shrink-0">
+      {/* Logo */}
+      <div className="p-6 border-b border-white/10">
+        <div className="flex items-center gap-2">
+          <span className="text-xl font-bold text-white">Doly</span>
+          <span className="text-[10px] font-semibold tracking-widest uppercase px-1.5 py-0.5 border border-white/40 text-white/70 rounded">
+            Dentons
+          </span>
+        </div>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex-1 p-4 space-y-1">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href || pathname.startsWith(href + "/");
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                active
+                  ? "bg-white/20 text-white"
+                  : "text-white/60 hover:text-white hover:bg-white/10"
+              }`}
+            >
+              <Icon className="w-4 h-4 flex-shrink-0" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Sign out */}
+      <div className="p-4 border-t border-white/10">
+        <button
+          onClick={handleSignOut}
+          className="flex items-center gap-3 px-3 py-2 w-full rounded-lg text-sm font-medium text-white/60 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <LogOut className="w-4 h-4 flex-shrink-0" />
+          Sign out
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,9 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["@xenova/transformers"],
   },
+  images: {
+    remotePatterns: [{ protocol: "https", hostname: "**" }],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Sidebar nav component with Dentons purple theme and active route highlighting
- `LawyerCard` component with avatar initials, top jurisdiction badges, languages, and reputation score
- `LawyersDirectory` client component with name/office search, jurisdiction filter, and language filter
- `LawyersPage` server component fetching all lawyers from Supabase ordered by reputation score

## Demo impact
Completes the Phase 0 lawyer directory exit criteria — `/lawyers` now shows all 15 seeded lawyers, searchable and filterable.

Closes #7