### PR TITLE
feat: Profile edit page

### DIFF
--- a/app/api/lawyers/[id]/route.ts
+++ b/app/api/lawyers/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 
 export async function GET(
   _req: Request,
@@ -48,4 +48,64 @@ export async function GET(
     jurisdictions: jurisdictionsResult.data,
     reputation_events: eventsResult.data,
   });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Ownership check by email — seed data IDs don't match auth UIDs
+  const { data: lawyer } = await supabase
+    .from("lawyers")
+    .select("id, email, timezone")
+    .eq("id", params.id)
+    .single();
+
+  if (!lawyer || lawyer.email !== user.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const { bio, title, full_name, languages, jurisdictions, availability } = body;
+
+  // Use service client — ownership already verified above
+  const service = createServiceClient();
+
+  await service
+    .from("lawyers")
+    .update({ bio, title, full_name, languages })
+    .eq("id", params.id);
+
+  if (Array.isArray(jurisdictions)) {
+    await service.from("lawyer_jurisdictions").delete().eq("lawyer_id", params.id);
+    if (jurisdictions.length > 0) {
+      await service.from("lawyer_jurisdictions").insert(
+        jurisdictions.map((j: Record<string, unknown>) => ({ ...j, lawyer_id: params.id }))
+      );
+    }
+  }
+
+  if (Array.isArray(availability)) {
+    await service.from("lawyer_availability").delete().eq("lawyer_id", params.id);
+    if (availability.length > 0) {
+      await service.from("lawyer_availability").insert(
+        availability.map((a: Record<string, unknown>) => ({
+          ...a,
+          lawyer_id: params.id,
+          timezone: lawyer.timezone,
+        }))
+      );
+    }
+  }
+
+  // TODO: Trigger embedding regeneration (issue #25)
+
+  return NextResponse.json({ success: true });
 }

--- a/app/api/lawyers/[id]/route.ts
+++ b/app/api/lawyers/[id]/route.ts
@@ -15,17 +15,17 @@ export async function GET(
   const [lawyerResult, jurisdictionsResult, eventsResult] = await Promise.all([
     supabase
       .from("lawyers")
-      .select("*")
+      .select("id, full_name, title, office_city, office_country, timezone, languages, bio, avatar_url, reputation_score, matters_count, contributions")
       .eq("id", params.id)
       .single(),
     supabase
       .from("lawyer_jurisdictions")
-      .select("*")
+      .select("id, jurisdiction_code, jurisdiction_name, expertise_level, matter_types, years_experience")
       .eq("lawyer_id", params.id)
       .order("expertise_level", { ascending: false }),
     supabase
       .from("reputation_events")
-      .select("*")
+      .select("id, event_type, points, description, created_at")
       .eq("lawyer_id", params.id)
       .order("created_at", { ascending: false })
       .limit(5),
@@ -35,9 +35,17 @@ export async function GET(
     return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
   }
 
+  if (jurisdictionsResult.error) {
+    return NextResponse.json({ error: "Failed to load jurisdictions" }, { status: 500 });
+  }
+
+  if (eventsResult.error) {
+    return NextResponse.json({ error: "Failed to load reputation events" }, { status: 500 });
+  }
+
   return NextResponse.json({
     lawyer: lawyerResult.data,
-    jurisdictions: jurisdictionsResult.data ?? [],
-    reputation_events: eventsResult.data ?? [],
+    jurisdictions: jurisdictionsResult.data,
+    reputation_events: eventsResult.data,
   });
 }

--- a/app/api/lawyers/[id]/route.ts
+++ b/app/api/lawyers/[id]/route.ts
@@ -72,36 +72,91 @@ export async function PATCH(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const body = await req.json();
+  let body: {
+    bio?: string;
+    title?: string;
+    full_name?: string;
+    languages?: string[];
+    jurisdictions?: { jurisdiction_code: string; jurisdiction_name: string; expertise_level: number; matter_types: string[]; years_experience: number }[];
+    availability?: { day_of_week: number; work_start_hour: number; work_end_hour: number }[];
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
   const { bio, title, full_name, languages, jurisdictions, availability } = body;
 
   // Use service client — ownership already verified above
   const service = createServiceClient();
 
-  await service
+  const { error: updateError } = await service
     .from("lawyers")
     .update({ bio, title, full_name, languages })
     .eq("id", params.id);
 
+  if (updateError) {
+    return NextResponse.json({ error: "Failed to update profile" }, { status: 500 });
+  }
+
   if (Array.isArray(jurisdictions)) {
-    await service.from("lawyer_jurisdictions").delete().eq("lawyer_id", params.id);
+    const { error: deleteJurError } = await service
+      .from("lawyer_jurisdictions")
+      .delete()
+      .eq("lawyer_id", params.id);
+
+    if (deleteJurError) {
+      return NextResponse.json({ error: "Failed to update jurisdictions" }, { status: 500 });
+    }
+
     if (jurisdictions.length > 0) {
-      await service.from("lawyer_jurisdictions").insert(
-        jurisdictions.map((j: Record<string, unknown>) => ({ ...j, lawyer_id: params.id }))
-      );
+      const { error: insertJurError } = await service
+        .from("lawyer_jurisdictions")
+        .insert(
+          jurisdictions.map((j) => ({
+            lawyer_id: params.id,
+            jurisdiction_code: j.jurisdiction_code,
+            jurisdiction_name: j.jurisdiction_name,
+            expertise_level: j.expertise_level,
+            matter_types: j.matter_types,
+            years_experience: j.years_experience,
+          }))
+        );
+
+      if (insertJurError) {
+        return NextResponse.json({ error: "Failed to save jurisdictions" }, { status: 500 });
+      }
     }
   }
 
   if (Array.isArray(availability)) {
-    await service.from("lawyer_availability").delete().eq("lawyer_id", params.id);
+    const { error: deleteAvailError } = await service
+      .from("lawyer_availability")
+      .delete()
+      .eq("lawyer_id", params.id);
+
+    if (deleteAvailError) {
+      return NextResponse.json({ error: "Failed to update availability" }, { status: 500 });
+    }
+
     if (availability.length > 0) {
-      await service.from("lawyer_availability").insert(
-        availability.map((a: Record<string, unknown>) => ({
-          ...a,
-          lawyer_id: params.id,
-          timezone: lawyer.timezone,
-        }))
-      );
+      const { error: insertAvailError } = await service
+        .from("lawyer_availability")
+        .insert(
+          availability.map((a) => ({
+            lawyer_id: params.id,
+            timezone: lawyer.timezone,
+            day_of_week: a.day_of_week,
+            work_start_hour: a.work_start_hour,
+            work_end_hour: a.work_end_hour,
+          }))
+        );
+
+      if (insertAvailError) {
+        return NextResponse.json({ error: "Failed to save availability" }, { status: 500 });
+      }
     }
   }
 

--- a/app/api/lawyers/[id]/route.ts
+++ b/app/api/lawyers/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const [lawyerResult, jurisdictionsResult, eventsResult] = await Promise.all([
+    supabase
+      .from("lawyers")
+      .select("*")
+      .eq("id", params.id)
+      .single(),
+    supabase
+      .from("lawyer_jurisdictions")
+      .select("*")
+      .eq("lawyer_id", params.id)
+      .order("expertise_level", { ascending: false }),
+    supabase
+      .from("reputation_events")
+      .select("*")
+      .eq("lawyer_id", params.id)
+      .order("created_at", { ascending: false })
+      .limit(5),
+  ]);
+
+  if (lawyerResult.error || !lawyerResult.data) {
+    return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    lawyer: lawyerResult.data,
+    jurisdictions: jurisdictionsResult.data ?? [],
+    reputation_events: eventsResult.data ?? [],
+  });
+}

--- a/app/lawyers/[id]/page.tsx
+++ b/app/lawyers/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { ArrowLeft, MapPin, Globe, Briefcase } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import Sidebar from "@/components/layout/Sidebar";
@@ -29,15 +30,19 @@ export default async function LawyerProfilePage({ params }: { params: { id: stri
   const supabase = createClient();
 
   const [lawyerResult, jurisdictionsResult, eventsResult] = await Promise.all([
-    supabase.from("lawyers").select("*").eq("id", params.id).single(),
+    supabase
+      .from("lawyers")
+      .select("id, full_name, title, office_city, office_country, timezone, languages, bio, avatar_url, reputation_score, matters_count, contributions")
+      .eq("id", params.id)
+      .single(),
     supabase
       .from("lawyer_jurisdictions")
-      .select("*")
+      .select("id, jurisdiction_code, jurisdiction_name, expertise_level, matter_types, years_experience")
       .eq("lawyer_id", params.id)
       .order("expertise_level", { ascending: false }),
     supabase
       .from("reputation_events")
-      .select("*")
+      .select("id, event_type, points, description, created_at")
       .eq("lawyer_id", params.id)
       .order("created_at", { ascending: false })
       .limit(5),
@@ -45,9 +50,17 @@ export default async function LawyerProfilePage({ params }: { params: { id: stri
 
   if (lawyerResult.error || !lawyerResult.data) notFound();
 
+  if (jurisdictionsResult.error) {
+    throw new Error(`Failed to load jurisdictions: ${jurisdictionsResult.error.message}`);
+  }
+
+  if (eventsResult.error) {
+    throw new Error(`Failed to load reputation events: ${eventsResult.error.message}`);
+  }
+
   const lawyer = lawyerResult.data as Lawyer;
-  const jurisdictions = (jurisdictionsResult.data ?? []) as LawyerJurisdiction[];
-  const events = (eventsResult.data ?? []) as ReputationEvent[];
+  const jurisdictions = jurisdictionsResult.data as LawyerJurisdiction[];
+  const events = eventsResult.data as ReputationEvent[];
 
   return (
     <div className="flex min-h-screen bg-brand-grey-bg">
@@ -67,10 +80,12 @@ export default async function LawyerProfilePage({ params }: { params: { id: stri
           <div className="flex items-start gap-5">
             <div className="w-16 h-16 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
               {lawyer.avatar_url ? (
-                <img
+                <Image
                   src={lawyer.avatar_url}
                   alt={lawyer.full_name}
-                  className="w-16 h-16 rounded-full object-cover"
+                  width={64}
+                  height={64}
+                  className="rounded-full object-cover"
                 />
               ) : (
                 <span className="text-brand-purple font-bold text-xl">

--- a/app/lawyers/[id]/page.tsx
+++ b/app/lawyers/[id]/page.tsx
@@ -1,0 +1,163 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, MapPin, Globe, Briefcase } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import Sidebar from "@/components/layout/Sidebar";
+import JurisdictionMatrix from "@/components/lawyers/JurisdictionMatrix";
+import ReputationBadge from "@/components/reputation/ReputationBadge";
+import type { Lawyer, LawyerJurisdiction, ReputationEvent } from "@/types";
+
+const eventLabels: Record<ReputationEvent["event_type"], string> = {
+  matter_joined:      "Joined a matter",
+  brief_generated:    "Generated jurisdiction brief",
+  note_contributed:   "Contributed a field note",
+  note_upvoted:       "Field note upvoted",
+  handoff_completed:  "Completed task handoff",
+  match_accepted:     "Accepted as expert match",
+  profile_completed:  "Completed profile",
+  cross_border_matter:"Led cross-border matter",
+};
+
+function Initials({ name }: { name: string }) {
+  const parts = name.trim().split(" ");
+  return parts.length >= 2
+    ? `${parts[0][0]}${parts[parts.length - 1][0]}`
+    : name[0];
+}
+
+export default async function LawyerProfilePage({ params }: { params: { id: string } }) {
+  const supabase = createClient();
+
+  const [lawyerResult, jurisdictionsResult, eventsResult] = await Promise.all([
+    supabase.from("lawyers").select("*").eq("id", params.id).single(),
+    supabase
+      .from("lawyer_jurisdictions")
+      .select("*")
+      .eq("lawyer_id", params.id)
+      .order("expertise_level", { ascending: false }),
+    supabase
+      .from("reputation_events")
+      .select("*")
+      .eq("lawyer_id", params.id)
+      .order("created_at", { ascending: false })
+      .limit(5),
+  ]);
+
+  if (lawyerResult.error || !lawyerResult.data) notFound();
+
+  const lawyer = lawyerResult.data as Lawyer;
+  const jurisdictions = (jurisdictionsResult.data ?? []) as LawyerJurisdiction[];
+  const events = (eventsResult.data ?? []) as ReputationEvent[];
+
+  return (
+    <div className="flex min-h-screen bg-brand-grey-bg">
+      <Sidebar />
+      <main className="flex-1 p-8 max-w-4xl">
+        {/* Back */}
+        <Link
+          href="/lawyers"
+          className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 transition-colors mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to directory
+        </Link>
+
+        {/* Hero */}
+        <div className="bg-white border border-brand-grey rounded-xl p-6 mb-4">
+          <div className="flex items-start gap-5">
+            <div className="w-16 h-16 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
+              {lawyer.avatar_url ? (
+                <img
+                  src={lawyer.avatar_url}
+                  alt={lawyer.full_name}
+                  className="w-16 h-16 rounded-full object-cover"
+                />
+              ) : (
+                <span className="text-brand-purple font-bold text-xl">
+                  <Initials name={lawyer.full_name} />
+                </span>
+              )}
+            </div>
+
+            <div className="flex-1 min-w-0">
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                  <h1 className="text-xl font-bold text-gray-900">{lawyer.full_name}</h1>
+                  <p className="text-gray-500 text-sm mt-0.5">{lawyer.title}</p>
+                </div>
+                <ReputationBadge score={lawyer.reputation_score} />
+              </div>
+
+              <div className="flex flex-wrap gap-4 mt-3 text-sm text-gray-500">
+                <span className="flex items-center gap-1.5">
+                  <MapPin className="w-3.5 h-3.5 flex-shrink-0" />
+                  {lawyer.office_city}, {lawyer.office_country}
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <Globe className="w-3.5 h-3.5 flex-shrink-0" />
+                  {lawyer.languages.join(", ")}
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <Briefcase className="w-3.5 h-3.5 flex-shrink-0" />
+                  {lawyer.matters_count} cross-border matters
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Bio */}
+        {lawyer.bio && (
+          <div className="bg-white border border-brand-grey rounded-xl p-6 mb-4">
+            <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">About</h2>
+            <p className="text-gray-700 text-sm leading-relaxed">{lawyer.bio}</p>
+          </div>
+        )}
+
+        {/* Jurisdiction Matrix */}
+        <div className="bg-white border border-brand-grey rounded-xl p-6 mb-4">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide">
+              Jurisdiction Expertise
+            </h2>
+            <span className="text-xs text-gray-400">{jurisdictions.length} jurisdictions</span>
+          </div>
+          <JurisdictionMatrix jurisdictions={jurisdictions} />
+        </div>
+
+        {/* Reputation */}
+        <div className="bg-white border border-brand-grey rounded-xl p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide">
+              Reputation
+            </h2>
+            <span className="text-2xl font-bold text-gray-900">
+              {lawyer.reputation_score.toLocaleString()}
+              <span className="text-sm font-normal text-gray-400 ml-1">pts</span>
+            </span>
+          </div>
+
+          {events.length > 0 ? (
+            <ul className="divide-y divide-gray-100">
+              {events.map((event) => (
+                <li key={event.id} className="flex items-center justify-between py-3">
+                  <div>
+                    <p className="text-sm text-gray-700">{eventLabels[event.event_type]}</p>
+                    {event.description && (
+                      <p className="text-xs text-gray-400 mt-0.5">{event.description}</p>
+                    )}
+                  </div>
+                  <span className="text-sm font-semibold text-green-600 flex-shrink-0 ml-4">
+                    +{event.points}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-400">No recent activity.</p>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/lawyers/_components/LawyersDirectory.tsx
+++ b/app/lawyers/_components/LawyersDirectory.tsx
@@ -63,6 +63,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
           <input
             type="text"
+            aria-label="Search lawyers by name or office"
             placeholder="Search by name or office..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -71,6 +72,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
         </div>
 
         <select
+          aria-label="Filter by jurisdiction"
           value={selectedJurisdiction}
           onChange={(e) => setSelectedJurisdiction(e.target.value)}
           className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
@@ -82,6 +84,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
         </select>
 
         <select
+          aria-label="Filter by language"
           value={selectedLanguage}
           onChange={(e) => setSelectedLanguage(e.target.value)}
           className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
@@ -105,7 +108,7 @@ export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJuris
       {/* Results */}
       {filtered.length === 0 ? (
         <div className="text-center py-16">
-          <p className="text-gray-400 text-sm">No lawyers match your filters.</p>
+          <p className="text-gray-400 text-sm">No lawyers match your search.</p>
           <button
             onClick={clearFilters}
             className="mt-2 text-brand-purple text-sm hover:underline"

--- a/app/lawyers/_components/LawyersDirectory.tsx
+++ b/app/lawyers/_components/LawyersDirectory.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Search } from "lucide-react";
+import LawyerCard, { type LawyerWithJurisdictions } from "@/components/lawyers/LawyerCard";
+
+export default function LawyersDirectory({ lawyers }: { lawyers: LawyerWithJurisdictions[] }) {
+  const [search, setSearch] = useState("");
+  const [selectedJurisdiction, setSelectedJurisdiction] = useState("");
+  const [selectedLanguage, setSelectedLanguage] = useState("");
+
+  const allJurisdictions = useMemo(() => {
+    const codes = new Set<string>();
+    lawyers.forEach((l) => l.lawyer_jurisdictions.forEach((j) => codes.add(j.jurisdiction_code)));
+    return Array.from(codes).sort();
+  }, [lawyers]);
+
+  const allLanguages = useMemo(() => {
+    const langs = new Set<string>();
+    lawyers.forEach((l) => l.languages.forEach((lang) => langs.add(lang)));
+    return Array.from(langs).sort();
+  }, [lawyers]);
+
+  const filtered = useMemo(() => {
+    return lawyers.filter((l) => {
+      const matchesSearch =
+        !search ||
+        l.full_name.toLowerCase().includes(search.toLowerCase()) ||
+        l.office_city.toLowerCase().includes(search.toLowerCase()) ||
+        l.office_country.toLowerCase().includes(search.toLowerCase());
+
+      const matchesJurisdiction =
+        !selectedJurisdiction ||
+        l.lawyer_jurisdictions.some((j) => j.jurisdiction_code === selectedJurisdiction);
+
+      const matchesLanguage =
+        !selectedLanguage ||
+        l.languages.some((lang) => lang.toLowerCase() === selectedLanguage.toLowerCase());
+
+      return matchesSearch && matchesJurisdiction && matchesLanguage;
+    });
+  }, [lawyers, search, selectedJurisdiction, selectedLanguage]);
+
+  const hasFilters = search || selectedJurisdiction || selectedLanguage;
+
+  function clearFilters() {
+    setSearch("");
+    setSelectedJurisdiction("");
+    setSelectedLanguage("");
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Lawyer Directory</h1>
+        <p className="text-sm text-gray-500 mt-1">{lawyers.length} lawyers across the firm</p>
+      </div>
+
+      {/* Search + filters */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div className="relative flex-1 min-w-[220px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search by name or office..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-4 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+          />
+        </div>
+
+        <select
+          value={selectedJurisdiction}
+          onChange={(e) => setSelectedJurisdiction(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+        >
+          <option value="">All jurisdictions</option>
+          {allJurisdictions.map((j) => (
+            <option key={j} value={j}>{j}</option>
+          ))}
+        </select>
+
+        <select
+          value={selectedLanguage}
+          onChange={(e) => setSelectedLanguage(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-brand-grey bg-white text-sm text-gray-700 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+        >
+          <option value="">All languages</option>
+          {allLanguages.map((lang) => (
+            <option key={lang} value={lang}>{lang}</option>
+          ))}
+        </select>
+
+        {hasFilters && (
+          <button
+            onClick={clearFilters}
+            className="px-3 py-2 rounded-lg text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Results */}
+      {filtered.length === 0 ? (
+        <div className="text-center py-16">
+          <p className="text-gray-400 text-sm">No lawyers match your filters.</p>
+          <button
+            onClick={clearFilters}
+            className="mt-2 text-brand-purple text-sm hover:underline"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : (
+        <>
+          {hasFilters && (
+            <p className="text-sm text-gray-400 mb-4">
+              {filtered.length} result{filtered.length !== 1 ? "s" : ""}
+            </p>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map((lawyer) => (
+              <LawyerCard key={lawyer.id} lawyer={lawyer} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/lawyers/page.tsx
+++ b/app/lawyers/page.tsx
@@ -16,7 +16,7 @@ export default async function LawyersPage() {
     .order("reputation_score", { ascending: false });
 
   if (error) {
-    console.error("Failed to load lawyers:", error.message);
+    throw new Error(`Failed to load lawyers: ${error.message}`);
   }
 
   const lawyers = (data ?? []) as unknown as LawyerWithJurisdictions[];

--- a/app/lawyers/page.tsx
+++ b/app/lawyers/page.tsx
@@ -1,8 +1,32 @@
-export default function LawyersPage() {
+import { createClient } from "@/lib/supabase/server";
+import Sidebar from "@/components/layout/Sidebar";
+import LawyersDirectory from "./_components/LawyersDirectory";
+import type { LawyerWithJurisdictions } from "@/components/lawyers/LawyerCard";
+
+export default async function LawyersPage() {
+  const supabase = createClient();
+
+  const { data, error } = await supabase
+    .from("lawyers")
+    .select(`
+      id, full_name, title, office_city, office_country,
+      languages, reputation_score, matters_count, avatar_url,
+      lawyer_jurisdictions(jurisdiction_code, jurisdiction_name, expertise_level)
+    `)
+    .order("reputation_score", { ascending: false });
+
+  if (error) {
+    console.error("Failed to load lawyers:", error.message);
+  }
+
+  const lawyers = (data ?? []) as unknown as LawyerWithJurisdictions[];
+
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold text-white">Lawyers</h1>
-      <p className="text-slate-400 mt-2">Coming soon — Phase 0</p>
+    <div className="flex min-h-screen bg-brand-grey-bg">
+      <Sidebar />
+      <main className="flex-1 p-8">
+        <LawyersDirectory lawyers={lawyers} />
+      </main>
     </div>
   );
 }

--- a/app/profile/_components/ProfileForm.tsx
+++ b/app/profile/_components/ProfileForm.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Plus, X, Check } from "lucide-react";
+import type { Lawyer, LawyerJurisdiction, LawyerAvailability } from "@/types";
+
+const LANGUAGES = [
+  "Arabic", "Dutch", "English", "French", "German", "Hindi",
+  "Italian", "Japanese", "Korean", "Malay", "Mandarin",
+  "Portuguese", "Russian", "Spanish", "Turkish",
+];
+
+const MATTER_TYPES = [
+  "Banking", "Competition", "Corporate", "Data Privacy", "Employment",
+  "Fintech", "IP", "Litigation", "M&A", "Real Estate", "Regulatory",
+  "Restructuring", "Tax", "Tech",
+];
+
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+type JurRow = {
+  jurisdiction_code: string;
+  jurisdiction_name: string;
+  expertise_level: 1 | 2 | 3 | 4 | 5;
+  matter_types: string[];
+  years_experience: number;
+};
+
+type AvailDay = {
+  day_of_week: number;
+  day_name: string;
+  enabled: boolean;
+  work_start_hour: number;
+  work_end_hour: number;
+};
+
+type Props = {
+  lawyer: Lawyer;
+  jurisdictions: LawyerJurisdiction[];
+  availability: LawyerAvailability[];
+};
+
+export default function ProfileForm({ lawyer, jurisdictions: initialJur, availability: initialAvail }: Props) {
+  const [bio, setBio] = useState(lawyer.bio ?? "");
+  const [title, setTitle] = useState(lawyer.title ?? "");
+  const [fullName, setFullName] = useState(lawyer.full_name ?? "");
+  const [languages, setLanguages] = useState<string[]>(lawyer.languages ?? []);
+
+  const [jurisdictions, setJurisdictions] = useState<JurRow[]>(
+    initialJur.map(({ jurisdiction_code, jurisdiction_name, expertise_level, matter_types, years_experience }) => ({
+      jurisdiction_code, jurisdiction_name, expertise_level, matter_types, years_experience,
+    }))
+  );
+  const [addingJuris, setAddingJuris] = useState(false);
+  const [newJuris, setNewJuris] = useState<JurRow>({
+    jurisdiction_code: "", jurisdiction_name: "", expertise_level: 3, matter_types: [], years_experience: 1,
+  });
+
+  const [availability, setAvailability] = useState<AvailDay[]>(
+    DAYS.map((day_name, day_of_week) => {
+      const existing = initialAvail.find((a) => a.day_of_week === day_of_week);
+      return {
+        day_of_week, day_name,
+        enabled: !!existing,
+        work_start_hour: existing?.work_start_hour ?? 9,
+        work_end_hour: existing?.work_end_hour ?? 18,
+      };
+    })
+  );
+
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const completeness = useMemo(() => {
+    let score = 0;
+    if (bio.trim().length > 20) score += 25;
+    if (languages.length >= 2) score += 25;
+    if (jurisdictions.length >= 1) score += 25;
+    if (availability.some((a) => a.enabled)) score += 25;
+    return score;
+  }, [bio, languages, jurisdictions, availability]);
+
+  function toggleLanguage(lang: string) {
+    setLanguages((prev) => prev.includes(lang) ? prev.filter((l) => l !== lang) : [...prev, lang]);
+  }
+
+  function toggleNewMatterType(type: string) {
+    setNewJuris((prev) => ({
+      ...prev,
+      matter_types: prev.matter_types.includes(type)
+        ? prev.matter_types.filter((t) => t !== type)
+        : [...prev.matter_types, type],
+    }));
+  }
+
+  function addJurisdiction() {
+    if (!newJuris.jurisdiction_code || !newJuris.jurisdiction_name) return;
+    if (jurisdictions.some((j) => j.jurisdiction_code === newJuris.jurisdiction_code)) return;
+    setJurisdictions((prev) => [...prev, { ...newJuris }]);
+    setNewJuris({ jurisdiction_code: "", jurisdiction_name: "", expertise_level: 3, matter_types: [], years_experience: 1 });
+    setAddingJuris(false);
+  }
+
+  function updateAvailability(day_of_week: number, field: "enabled" | "work_start_hour" | "work_end_hour", value: boolean | number) {
+    setAvailability((prev) => prev.map((a) => a.day_of_week === day_of_week ? { ...a, [field]: value } : a));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/lawyers/${lawyer.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bio, title, full_name: fullName, languages, jurisdictions,
+          availability: availability
+            .filter((a) => a.enabled)
+            .map(({ day_of_week, work_start_hour, work_end_hour }) => ({ day_of_week, work_start_hour, work_end_hour })),
+        }),
+      });
+      if (!res.ok) throw new Error();
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch {
+      setError("Failed to save. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">My Profile</h1>
+          <p className="text-sm text-gray-500 mt-1">Keep your expertise up to date to improve match quality</p>
+        </div>
+        <div className="flex items-center gap-3">
+          {saved && (
+            <span className="flex items-center gap-1.5 text-sm text-green-600 font-medium">
+              <Check className="w-4 h-4" /> Profile updated
+            </span>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="px-4 py-2 bg-brand-purple text-white text-sm font-medium rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">
+          {error}
+        </div>
+      )}
+
+      {/* Completeness */}
+      <div className="bg-white border border-brand-grey rounded-xl p-5 mb-4">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium text-gray-700">Profile completeness</span>
+          <span className="text-sm font-semibold text-brand-purple">{completeness}%</span>
+        </div>
+        <div className="w-full h-2 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-brand-purple rounded-full transition-all duration-500"
+            style={{ width: `${completeness}%` }}
+          />
+        </div>
+        {completeness < 100 && (
+          <p className="text-xs text-gray-400 mt-2">
+            Complete your profile to unlock{" "}
+            <span className="font-semibold text-brand-purple">+60 reputation points</span>
+          </p>
+        )}
+      </div>
+
+      {/* Basic Info */}
+      <div className="bg-white border border-brand-grey rounded-xl p-6 mb-4 space-y-4">
+        <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide">Basic Info</h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1.5">Full name</label>
+            <input
+              type="text"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-brand-grey text-sm text-gray-900 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1.5">Title</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-brand-grey text-sm text-gray-900 focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1.5">Bio</label>
+          <textarea
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            rows={4}
+            placeholder="Describe your expertise, experience, and focus areas..."
+            className="w-full px-3 py-2 rounded-lg border border-brand-grey text-sm text-gray-900 placeholder-gray-400 resize-none focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-2">Languages</label>
+          <div className="flex flex-wrap gap-2">
+            {LANGUAGES.map((lang) => (
+              <button
+                key={lang}
+                type="button"
+                onClick={() => toggleLanguage(lang)}
+                className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
+                  languages.includes(lang)
+                    ? "bg-brand-purple text-white border-brand-purple"
+                    : "bg-white text-gray-500 border-brand-grey hover:border-brand-purple hover:text-brand-purple"
+                }`}
+              >
+                {lang}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Jurisdictions */}
+      <div className="bg-white border border-brand-grey rounded-xl p-6 mb-4">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide">
+            Jurisdiction Expertise
+          </h2>
+          {!addingJuris && (
+            <button
+              type="button"
+              onClick={() => setAddingJuris(true)}
+              className="flex items-center gap-1 text-xs text-brand-purple hover:text-brand-purple-dark font-medium transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" /> Add jurisdiction
+            </button>
+          )}
+        </div>
+
+        {jurisdictions.length === 0 && !addingJuris && (
+          <p className="text-sm text-gray-400">No jurisdictions added yet.</p>
+        )}
+
+        {jurisdictions.length > 0 && (
+          <div className="space-y-2 mb-3">
+            {jurisdictions.map((j) => (
+              <div key={j.jurisdiction_code} className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
+                <span className="text-xs font-semibold px-2 py-0.5 bg-brand-purple/10 text-brand-purple rounded border border-brand-purple/20 w-10 text-center flex-shrink-0">
+                  {j.jurisdiction_code}
+                </span>
+                <span className="text-sm text-gray-700 flex-1 truncate">{j.jurisdiction_name}</span>
+                <span className="text-xs text-amber-500 flex-shrink-0 tracking-tighter">
+                  {"★".repeat(j.expertise_level)}
+                  <span className="text-gray-200">{"★".repeat(5 - j.expertise_level)}</span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setJurisdictions((prev) => prev.filter((x) => x.jurisdiction_code !== j.jurisdiction_code))}
+                  className="text-gray-300 hover:text-red-400 transition-colors flex-shrink-0"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {addingJuris && (
+          <div className="border border-brand-purple/30 rounded-lg p-4 mt-2 space-y-3 bg-brand-purple/5">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Code (e.g. BR)</label>
+                <input
+                  type="text"
+                  maxLength={5}
+                  value={newJuris.jurisdiction_code}
+                  onChange={(e) => setNewJuris((p) => ({ ...p, jurisdiction_code: e.target.value.toUpperCase() }))}
+                  placeholder="BR"
+                  className="w-full px-3 py-2 rounded-lg border border-brand-grey text-sm focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={newJuris.jurisdiction_name}
+                  onChange={(e) => setNewJuris((p) => ({ ...p, jurisdiction_name: e.target.value }))}
+                  placeholder="Brazil"
+                  className="w-full px-3 py-2 rounded-lg border border-brand-grey text-sm focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  Expertise — {newJuris.expertise_level}/5
+                </label>
+                <input
+                  type="range"
+                  min={1}
+                  max={5}
+                  value={newJuris.expertise_level}
+                  onChange={(e) => setNewJuris((p) => ({ ...p, expertise_level: Number(e.target.value) as 1|2|3|4|5 }))}
+                  className="w-full accent-brand-purple"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Years experience</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={40}
+                  value={newJuris.years_experience}
+                  onChange={(e) => setNewJuris((p) => ({ ...p, years_experience: Number(e.target.value) }))}
+                  className="w-full px-3 py-2 rounded-lg border border-brand-grey text-sm focus:outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple transition-colors"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-2">Matter types</label>
+              <div className="flex flex-wrap gap-1.5">
+                {MATTER_TYPES.map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onClick={() => toggleNewMatterType(type)}
+                    className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                      newJuris.matter_types.includes(type)
+                        ? "bg-brand-purple text-white border-brand-purple"
+                        : "bg-white text-gray-500 border-brand-grey hover:border-brand-purple"
+                    }`}
+                  >
+                    {type}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex gap-2 pt-1">
+              <button
+                type="button"
+                onClick={addJurisdiction}
+                disabled={!newJuris.jurisdiction_code || !newJuris.jurisdiction_name}
+                className="px-3 py-1.5 bg-brand-purple text-white text-xs font-medium rounded-lg hover:bg-brand-purple-dark disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                onClick={() => setAddingJuris(false)}
+                className="px-3 py-1.5 text-gray-500 text-xs hover:text-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Availability */}
+      <div className="bg-white border border-brand-grey rounded-xl p-6">
+        <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-4">
+          Availability
+        </h2>
+        <div className="space-y-3">
+          {availability.map((day) => (
+            <div key={day.day_of_week} className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => updateAvailability(day.day_of_week, "enabled", !day.enabled)}
+                className={`w-10 text-left text-sm font-medium transition-colors flex-shrink-0 ${
+                  day.enabled ? "text-gray-700" : "text-gray-300"
+                }`}
+              >
+                {day.day_name.slice(0, 3)}
+              </button>
+              {day.enabled ? (
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <select
+                    value={day.work_start_hour}
+                    onChange={(e) => updateAvailability(day.day_of_week, "work_start_hour", Number(e.target.value))}
+                    className="px-2 py-1 rounded border border-brand-grey text-xs focus:outline-none focus:border-brand-purple transition-colors"
+                  >
+                    {Array.from({ length: 13 }, (_, i) => i + 6).map((h) => (
+                      <option key={h} value={h}>{h}:00</option>
+                    ))}
+                  </select>
+                  <span className="text-gray-400 text-xs">to</span>
+                  <select
+                    value={day.work_end_hour}
+                    onChange={(e) => updateAvailability(day.day_of_week, "work_end_hour", Number(e.target.value))}
+                    className="px-2 py-1 rounded border border-brand-grey text-xs focus:outline-none focus:border-brand-purple transition-colors"
+                  >
+                    {Array.from({ length: 13 }, (_, i) => i + 12).map((h) => (
+                      <option key={h} value={h}>{h}:00</option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                <span className="text-xs text-gray-300">Off</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/profile/_components/ProfileForm.tsx
+++ b/app/profile/_components/ProfileForm.tsx
@@ -120,11 +120,28 @@ export default function ProfileForm({ lawyer, jurisdictions: initialJur, availab
             .map(({ day_of_week, work_start_hour, work_end_hour }) => ({ day_of_week, work_start_hour, work_end_hour })),
         }),
       });
-      if (!res.ok) throw new Error();
+
+      if (res.status === 401 || res.redirected) {
+        throw new Error("Your session has expired. Please sign in again.");
+      }
+      if (res.status === 403) {
+        throw new Error("You do not have permission to update this profile.");
+      }
+
+      const contentType = res.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        throw new Error("Unexpected server response. Please try again.");
+      }
+
+      const data = await res.json() as { success?: boolean; error?: string };
+      if (!res.ok || data.success !== true) {
+        throw new Error(data.error ?? "Failed to save. Please try again.");
+      }
+
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
-    } catch {
-      setError("Failed to save. Please try again.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -382,44 +399,62 @@ export default function ProfileForm({ lawyer, jurisdictions: initialJur, availab
           Availability
         </h2>
         <div className="space-y-3">
-          {availability.map((day) => (
-            <div key={day.day_of_week} className="flex items-center gap-4">
-              <button
-                type="button"
-                onClick={() => updateAvailability(day.day_of_week, "enabled", !day.enabled)}
-                className={`w-10 text-left text-sm font-medium transition-colors flex-shrink-0 ${
-                  day.enabled ? "text-gray-700" : "text-gray-300"
-                }`}
-              >
-                {day.day_name.slice(0, 3)}
-              </button>
-              {day.enabled ? (
-                <div className="flex items-center gap-2 text-sm text-gray-600">
-                  <select
-                    value={day.work_start_hour}
-                    onChange={(e) => updateAvailability(day.day_of_week, "work_start_hour", Number(e.target.value))}
-                    className="px-2 py-1 rounded border border-brand-grey text-xs focus:outline-none focus:border-brand-purple transition-colors"
-                  >
-                    {Array.from({ length: 13 }, (_, i) => i + 6).map((h) => (
-                      <option key={h} value={h}>{h}:00</option>
-                    ))}
-                  </select>
-                  <span className="text-gray-400 text-xs">to</span>
-                  <select
-                    value={day.work_end_hour}
-                    onChange={(e) => updateAvailability(day.day_of_week, "work_end_hour", Number(e.target.value))}
-                    className="px-2 py-1 rounded border border-brand-grey text-xs focus:outline-none focus:border-brand-purple transition-colors"
-                  >
-                    {Array.from({ length: 13 }, (_, i) => i + 12).map((h) => (
-                      <option key={h} value={h}>{h}:00</option>
-                    ))}
-                  </select>
-                </div>
-              ) : (
-                <span className="text-xs text-gray-300">Off</span>
-              )}
-            </div>
-          ))}
+          {availability.map((day) => {
+            const endHourOptions = Array.from({ length: 13 }, (_, i) => i + 12).filter(
+              (h) => h > day.work_start_hour
+            );
+            const safeEndHour = endHourOptions.includes(day.work_end_hour)
+              ? day.work_end_hour
+              : endHourOptions[0];
+
+            return (
+              <div key={day.day_of_week} className="flex items-center gap-4">
+                <button
+                  type="button"
+                  aria-pressed={day.enabled}
+                  onClick={() => updateAvailability(day.day_of_week, "enabled", !day.enabled)}
+                  className={`w-10 text-left text-sm font-medium transition-colors flex-shrink-0 ${
+                    day.enabled ? "text-gray-700" : "text-gray-300"
+                  }`}
+                >
+                  {day.day_name.slice(0, 3)}
+                </button>
+                {day.enabled ? (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <select
+                      aria-label={`${day.day_name} start time`}
+                      value={day.work_start_hour}
+                      onChange={(e) => {
+                        const next = Number(e.target.value);
+                        updateAvailability(day.day_of_week, "work_start_hour", next);
+                        if (day.work_end_hour <= next) {
+                          updateAvailability(day.day_of_week, "work_end_hour", next + 1);
+                        }
+                      }}
+                      className="px-2 py-1 rounded border border-brand-grey text-xs focus:outline-none focus:border-brand-purple transition-colors"
+                    >
+                      {Array.from({ length: 13 }, (_, i) => i + 6).map((h) => (
+                        <option key={h} value={h}>{h}:00</option>
+                      ))}
+                    </select>
+                    <span className="text-gray-400 text-xs">to</span>
+                    <select
+                      aria-label={`${day.day_name} end time`}
+                      value={safeEndHour}
+                      onChange={(e) => updateAvailability(day.day_of_week, "work_end_hour", Number(e.target.value))}
+                      className="px-2 py-1 rounded border border-brand-grey text-xs focus:outline-none focus:border-brand-purple transition-colors"
+                    >
+                      {endHourOptions.map((h) => (
+                        <option key={h} value={h}>{h}:00</option>
+                      ))}
+                    </select>
+                  </div>
+                ) : (
+                  <span className="text-xs text-gray-300">Off</span>
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,47 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import Sidebar from "@/components/layout/Sidebar";
+import ProfileForm from "./_components/ProfileForm";
+import type { Lawyer, LawyerJurisdiction, LawyerAvailability } from "@/types";
+
+export default async function ProfilePage() {
+  const supabase = createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  // Look up by email — seed data IDs don't match auth UIDs
+  const { data: lawyer } = await supabase
+    .from("lawyers")
+    .select("*")
+    .eq("email", user.email)
+    .single();
+
+  if (!lawyer) redirect("/dashboard");
+
+  const [jurisdictionsResult, availabilityResult] = await Promise.all([
+    supabase
+      .from("lawyer_jurisdictions")
+      .select("*")
+      .eq("lawyer_id", lawyer.id)
+      .order("expertise_level", { ascending: false }),
+    supabase
+      .from("lawyer_availability")
+      .select("*")
+      .eq("lawyer_id", lawyer.id)
+      .order("day_of_week"),
+  ]);
+
+  return (
+    <div className="flex min-h-screen bg-brand-grey-bg">
+      <Sidebar />
+      <main className="flex-1 p-8 max-w-3xl">
+        <ProfileForm
+          lawyer={lawyer as Lawyer}
+          jurisdictions={(jurisdictionsResult.data ?? []) as LawyerJurisdiction[]}
+          availability={(availabilityResult.data ?? []) as LawyerAvailability[]}
+        />
+      </main>
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -13,7 +13,7 @@ export default async function ProfilePage() {
   // Look up by email — seed data IDs don't match auth UIDs
   const { data: lawyer } = await supabase
     .from("lawyers")
-    .select("*")
+    .select("id, full_name, title, office_city, office_country, timezone, languages, bio, avatar_url, reputation_score, matters_count, contributions")
     .eq("email", user.email)
     .single();
 

--- a/components/lawyers/JurisdictionMatrix.tsx
+++ b/components/lawyers/JurisdictionMatrix.tsx
@@ -1,0 +1,92 @@
+import { Star } from "lucide-react";
+import type { LawyerJurisdiction } from "@/types";
+
+const expertiseColors: Record<number, string> = {
+  1: "bg-gray-100 text-gray-500 border-gray-200",
+  2: "bg-gray-100 text-gray-600 border-gray-300",
+  3: "bg-blue-50 text-blue-600 border-blue-200",
+  4: "bg-brand-purple/10 text-brand-purple border-brand-purple/20",
+  5: "bg-amber-50 text-amber-700 border-amber-200",
+};
+
+export default function JurisdictionMatrix({
+  jurisdictions,
+}: {
+  jurisdictions: LawyerJurisdiction[];
+}) {
+  if (jurisdictions.length === 0) {
+    return <p className="text-sm text-gray-400">No jurisdictions listed.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-brand-grey">
+            <th className="text-left py-2 pr-4 text-xs font-medium text-gray-400 uppercase tracking-wide w-20">
+              Code
+            </th>
+            <th className="text-left py-2 pr-4 text-xs font-medium text-gray-400 uppercase tracking-wide">
+              Jurisdiction
+            </th>
+            <th className="text-left py-2 pr-4 text-xs font-medium text-gray-400 uppercase tracking-wide">
+              Expertise
+            </th>
+            <th className="text-left py-2 pr-4 text-xs font-medium text-gray-400 uppercase tracking-wide hidden sm:table-cell">
+              Matter Types
+            </th>
+            <th className="text-right py-2 text-xs font-medium text-gray-400 uppercase tracking-wide hidden sm:table-cell">
+              Yrs
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {jurisdictions.map((j) => (
+            <tr key={j.jurisdiction_code} className="hover:bg-gray-50 transition-colors">
+              <td className="py-3 pr-4">
+                <span
+                  className={`inline-block text-xs font-semibold px-2 py-0.5 rounded border ${expertiseColors[j.expertise_level]}`}
+                >
+                  {j.jurisdiction_code}
+                </span>
+              </td>
+              <td className="py-3 pr-4 text-gray-700 font-medium">{j.jurisdiction_name}</td>
+              <td className="py-3 pr-4">
+                <div className="flex items-center gap-0.5">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Star
+                      key={i}
+                      className={`w-3.5 h-3.5 ${
+                        i < j.expertise_level
+                          ? "fill-amber-400 text-amber-400"
+                          : "text-gray-200"
+                      }`}
+                    />
+                  ))}
+                </div>
+              </td>
+              <td className="py-3 pr-4 hidden sm:table-cell">
+                <div className="flex flex-wrap gap-1">
+                  {j.matter_types.slice(0, 3).map((type) => (
+                    <span
+                      key={type}
+                      className="text-xs px-1.5 py-0.5 bg-gray-100 text-gray-500 rounded"
+                    >
+                      {type}
+                    </span>
+                  ))}
+                  {j.matter_types.length > 3 && (
+                    <span className="text-xs text-gray-400">+{j.matter_types.length - 3}</span>
+                  )}
+                </div>
+              </td>
+              <td className="py-3 text-right text-gray-500 hidden sm:table-cell">
+                {j.years_experience}y
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/lawyers/JurisdictionMatrix.tsx
+++ b/components/lawyers/JurisdictionMatrix.tsx
@@ -1,12 +1,13 @@
 import { Star } from "lucide-react";
 import type { LawyerJurisdiction } from "@/types";
 
+// Colour spec: grey=1–2, blue=3, gold=4–5
 const expertiseColors: Record<number, string> = {
   1: "bg-gray-100 text-gray-500 border-gray-200",
   2: "bg-gray-100 text-gray-600 border-gray-300",
   3: "bg-blue-50 text-blue-600 border-blue-200",
-  4: "bg-brand-purple/10 text-brand-purple border-brand-purple/20",
-  5: "bg-amber-50 text-amber-700 border-amber-200",
+  4: "bg-amber-50 text-amber-600 border-amber-200",
+  5: "bg-amber-50 text-amber-700 border-amber-300",
 };
 
 export default function JurisdictionMatrix({

--- a/components/lawyers/LawyerCard.tsx
+++ b/components/lawyers/LawyerCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import type { Lawyer, LawyerJurisdiction } from "@/types";
 
 export type LawyerWithJurisdictions = Pick<
@@ -31,10 +32,12 @@ export default function LawyerCard({ lawyer }: { lawyer: LawyerWithJurisdictions
       <div className="flex items-start gap-3 mb-4">
         <div className="w-10 h-10 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
           {lawyer.avatar_url ? (
-            <img
+            <Image
               src={lawyer.avatar_url}
               alt={lawyer.full_name}
-              className="w-10 h-10 rounded-full object-cover"
+              width={40}
+              height={40}
+              className="rounded-full object-cover"
             />
           ) : (
             <span className="text-brand-purple font-semibold text-sm">

--- a/components/lawyers/LawyerCard.tsx
+++ b/components/lawyers/LawyerCard.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import type { Lawyer, LawyerJurisdiction } from "@/types";
+
+export type LawyerWithJurisdictions = Pick<
+  Lawyer,
+  "id" | "full_name" | "title" | "office_city" | "office_country" | "languages" | "reputation_score" | "matters_count" | "avatar_url"
+> & {
+  lawyer_jurisdictions: Pick<LawyerJurisdiction, "jurisdiction_code" | "jurisdiction_name" | "expertise_level">[];
+};
+
+function Initials({ name }: { name: string }) {
+  const parts = name.trim().split(" ");
+  return parts.length >= 2
+    ? `${parts[0][0]}${parts[parts.length - 1][0]}`
+    : name[0];
+}
+
+export default function LawyerCard({ lawyer }: { lawyer: LawyerWithJurisdictions }) {
+  const topJurisdictions = [...lawyer.lawyer_jurisdictions]
+    .sort((a, b) => b.expertise_level - a.expertise_level)
+    .slice(0, 3);
+
+  const extraCount = lawyer.lawyer_jurisdictions.length - 3;
+
+  return (
+    <Link
+      href={`/lawyers/${lawyer.id}`}
+      className="bg-white border border-brand-grey rounded-xl p-5 hover:border-brand-purple hover:shadow-sm transition-all group block"
+    >
+      {/* Avatar + name */}
+      <div className="flex items-start gap-3 mb-4">
+        <div className="w-10 h-10 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
+          {lawyer.avatar_url ? (
+            <img
+              src={lawyer.avatar_url}
+              alt={lawyer.full_name}
+              className="w-10 h-10 rounded-full object-cover"
+            />
+          ) : (
+            <span className="text-brand-purple font-semibold text-sm">
+              <Initials name={lawyer.full_name} />
+            </span>
+          )}
+        </div>
+        <div className="min-w-0">
+          <p className="font-semibold text-gray-900 group-hover:text-brand-purple transition-colors truncate text-sm">
+            {lawyer.full_name}
+          </p>
+          <p className="text-xs text-gray-500 truncate">{lawyer.title}</p>
+          <p className="text-xs text-gray-400 mt-0.5">
+            {lawyer.office_city}, {lawyer.office_country}
+          </p>
+        </div>
+      </div>
+
+      {/* Jurisdiction badges */}
+      {topJurisdictions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {topJurisdictions.map((j) => (
+            <span
+              key={j.jurisdiction_code}
+              className="text-xs px-2 py-0.5 bg-brand-purple/10 text-brand-purple rounded-full border border-brand-purple/20"
+            >
+              {j.jurisdiction_code}
+            </span>
+          ))}
+          {extraCount > 0 && (
+            <span className="text-xs px-2 py-0.5 bg-gray-100 text-gray-400 rounded-full">
+              +{extraCount}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Languages + reputation */}
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-400 truncate">
+          {lawyer.languages.slice(0, 2).join(", ")}
+          {lawyer.languages.length > 2 && ` +${lawyer.languages.length - 2}`}
+        </p>
+        <div className="flex items-center gap-0.5 flex-shrink-0">
+          <span className="text-xs font-semibold text-gray-700">
+            {lawyer.reputation_score.toLocaleString()}
+          </span>
+          <span className="text-xs text-gray-400 ml-0.5">pts</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -19,7 +19,12 @@ export default function Sidebar() {
   const supabase = createClient();
 
   async function handleSignOut() {
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error("Sign-out failed:", error.message);
+      return;
+    }
+    router.refresh();
     router.push("/login");
   }
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { LayoutDashboard, Users, Briefcase, FileText, Award, LogOut } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+
+const navItems = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/lawyers", label: "Lawyers", icon: Users },
+  { href: "/matters", label: "Matters", icon: Briefcase },
+  { href: "/field-notes", label: "Field Notes", icon: FileText },
+  { href: "/reputation", label: "Reputation", icon: Award },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const supabase = createClient();
+
+  async function handleSignOut() {
+    await supabase.auth.signOut();
+    router.push("/login");
+  }
+
+  return (
+    <aside className="w-60 min-h-screen bg-brand-purple flex flex-col flex-shrink-0">
+      {/* Logo */}
+      <div className="p-6 border-b border-white/10">
+        <div className="flex items-center gap-2">
+          <span className="text-xl font-bold text-white">Doly</span>
+          <span className="text-[10px] font-semibold tracking-widest uppercase px-1.5 py-0.5 border border-white/40 text-white/70 rounded">
+            Dentons
+          </span>
+        </div>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex-1 p-4 space-y-1">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href || pathname.startsWith(href + "/");
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                active
+                  ? "bg-white/20 text-white"
+                  : "text-white/60 hover:text-white hover:bg-white/10"
+              }`}
+            >
+              <Icon className="w-4 h-4 flex-shrink-0" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Sign out */}
+      <div className="p-4 border-t border-white/10">
+        <button
+          onClick={handleSignOut}
+          className="flex items-center gap-3 px-3 py-2 w-full rounded-lg text-sm font-medium text-white/60 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <LogOut className="w-4 h-4 flex-shrink-0" />
+          Sign out
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/components/reputation/ReputationBadge.tsx
+++ b/components/reputation/ReputationBadge.tsx
@@ -1,0 +1,20 @@
+const tiers = [
+  { min: 1500, label: "Elite Partner",    classes: "bg-amber-50 text-amber-700 border-amber-300" },
+  { min: 1000, label: "Global Expert",    classes: "bg-brand-purple/10 text-brand-purple border-brand-purple/30" },
+  { min: 500,  label: "Regional Expert",  classes: "bg-blue-50 text-blue-600 border-blue-200" },
+  { min: 200,  label: "Rising Star",      classes: "bg-green-50 text-green-600 border-green-200" },
+  { min: 0,    label: "Contributor",      classes: "bg-gray-100 text-gray-500 border-gray-200" },
+];
+
+export function getTier(score: number) {
+  return tiers.find((t) => score >= t.min) ?? tiers[tiers.length - 1];
+}
+
+export default function ReputationBadge({ score }: { score: number }) {
+  const tier = getTier(score);
+  return (
+    <span className={`inline-block text-xs font-semibold px-2.5 py-1 rounded-full border ${tier.classes}`}>
+      {tier.label}
+    </span>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,9 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["@xenova/transformers"],
   },
+  images: {
+    remotePatterns: [{ protocol: "https", hostname: "**" }],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- `PATCH /api/lawyers/[id]` — updates bio, title, full name, languages, jurisdictions (delete + re-insert), and availability (delete + re-insert); ownership enforced by email check with 403 on mismatch
- `ProfileForm` client component with: basic info fields, language pill toggles, jurisdiction add/remove with expertise slider and matter type tags, day-of-week availability with hour selectors
- Profile completeness bar (bio + languages + jurisdictions + availability = 100%) with +60 rep points prompt
- `ProfilePage` server component looks up lawyer by auth email and pre-fills the form

## Notes
- Embedding regeneration after profile update is stubbed with a TODO comment — wired in issue #25
- Seed data IDs don't match auth UIDs, so ownership check uses email comparison on the server rather than relying on RLS

Closes #9