### PR TITLE
feat: Matter API

### DIFF
--- a/app/api/matters/[id]/route.ts
+++ b/app/api/matters/[id]/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+
+const patchMatterSchema = z.object({
+  status: z.enum(["active", "completed", "archived"]).optional(),
+  deadline: z
+    .string()
+    .refine((s) => !isNaN(Date.parse(s)), { message: "Invalid deadline date" })
+    .optional(),
+});
+
+async function getAuthenticatedLawyer() {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const service = createServiceClient();
+  const { data: lawyer } = await service
+    .from("lawyers")
+    .select("id, email")
+    .eq("email", user.email)
+    .single();
+
+  return lawyer;
+}
+
+async function checkTeamMembership(matterId: string, lawyerId: string) {
+  const service = createServiceClient();
+  const { data } = await service
+    .from("matter_team")
+    .select("role")
+    .eq("matter_id", matterId)
+    .eq("lawyer_id", lawyerId)
+    .single();
+  return data;
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const membership = await checkTeamMembership(params.id, lawyer.id);
+  if (!membership) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const service = createServiceClient();
+  const { data: matter, error } = await service
+    .from("matters")
+    .select(`
+      id, title, description, client_name, matter_type, status, deadline, created_at,
+      matter_jurisdictions(id, jurisdiction_code, jurisdiction_name),
+      matter_team(
+        id, role, match_score, joined_at,
+        lawyer:lawyers(id, full_name, title, office_city, office_country, reputation_score, avatar_url)
+      ),
+      context_briefs(id, jurisdiction_code, jurisdiction_name, status)
+    `)
+    .eq("id", params.id)
+    .single();
+
+  if (error || !matter) {
+    return NextResponse.json({ error: "Matter not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(matter);
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const membership = await checkTeamMembership(params.id, lawyer.id);
+  if (!membership) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = patchMatterSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const service = createServiceClient();
+  const { data: matter, error } = await service
+    .from("matters")
+    .update(parsed.data)
+    .eq("id", params.id)
+    .select("id, title, status, deadline")
+    .single();
+
+  if (error || !matter) {
+    return NextResponse.json({ error: "Failed to update matter" }, { status: 500 });
+  }
+
+  return NextResponse.json(matter);
+}

--- a/app/api/matters/[id]/route.ts
+++ b/app/api/matters/[id]/route.ts
@@ -13,26 +13,29 @@ const patchMatterSchema = z.object({
 async function getAuthenticatedLawyer() {
   const supabase = createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return null;
+  if (!user?.email) return null;
 
   const service = createServiceClient();
-  const { data: lawyer } = await service
+  const { data: lawyer, error } = await service
     .from("lawyers")
     .select("id, email")
     .eq("email", user.email)
-    .single();
+    .maybeSingle();
 
+  if (error) return null;
   return lawyer;
 }
 
 async function checkTeamMembership(matterId: string, lawyerId: string) {
   const service = createServiceClient();
-  const { data } = await service
+  const { data, error } = await service
     .from("matter_team")
     .select("role")
     .eq("matter_id", matterId)
     .eq("lawyer_id", lawyerId)
-    .single();
+    .maybeSingle();
+
+  if (error) return null;
   return data;
 }
 
@@ -99,6 +102,10 @@ export async function PATCH(
       { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
       { status: 400 }
     );
+  }
+
+  if (Object.keys(parsed.data).length === 0) {
+    return NextResponse.json({ error: "No fields to update" }, { status: 400 });
   }
 
   const service = createServiceClient();

--- a/app/api/matters/route.ts
+++ b/app/api/matters/route.ts
@@ -13,22 +13,24 @@ const createMatterSchema = z.object({
     .refine((s) => !isNaN(Date.parse(s)), { message: "Invalid deadline date" })
     .optional(),
   jurisdiction_codes: z
-    .array(z.string().min(2).max(10))
-    .min(1, "At least one jurisdiction is required"),
+    .array(z.string().min(2).max(10).transform((s) => s.trim().toUpperCase()))
+    .min(1, "At least one jurisdiction is required")
+    .transform((arr) => Array.from(new Set(arr))),
 });
 
 async function getAuthenticatedLawyer() {
   const supabase = createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return null;
+  if (!user?.email) return null;
 
   const service = createServiceClient();
-  const { data: lawyer } = await service
+  const { data: lawyer, error } = await service
     .from("lawyers")
     .select("id, email")
     .eq("email", user.email)
-    .single();
+    .maybeSingle();
 
+  if (error) return null;
   return lawyer;
 }
 

--- a/app/api/matters/route.ts
+++ b/app/api/matters/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { getJurisdictionName } from "@/lib/jurisdictions";
+
+const createMatterSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().optional().default(""),
+  client_name: z.string().min(1, "Client name is required"),
+  matter_type: z.string().min(1, "Matter type is required"),
+  deadline: z
+    .string()
+    .refine((s) => !isNaN(Date.parse(s)), { message: "Invalid deadline date" })
+    .optional(),
+  jurisdiction_codes: z
+    .array(z.string().min(2).max(10))
+    .min(1, "At least one jurisdiction is required"),
+});
+
+async function getAuthenticatedLawyer() {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const service = createServiceClient();
+  const { data: lawyer } = await service
+    .from("lawyers")
+    .select("id, email")
+    .eq("email", user.email)
+    .single();
+
+  return lawyer;
+}
+
+export async function POST(req: Request) {
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createMatterSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const { title, description, client_name, matter_type, deadline, jurisdiction_codes } = parsed.data;
+  const service = createServiceClient();
+
+  const { data: matter, error: matterError } = await service
+    .from("matters")
+    .insert({
+      title,
+      description,
+      client_name,
+      matter_type,
+      lead_lawyer_id: lawyer.id,
+      deadline: deadline ?? null,
+    })
+    .select("id, title, client_name, matter_type, status, deadline, created_at")
+    .single();
+
+  if (matterError || !matter) {
+    return NextResponse.json({ error: "Failed to create matter" }, { status: 500 });
+  }
+
+  const { error: jurisdictionError } = await service
+    .from("matter_jurisdictions")
+    .insert(
+      jurisdiction_codes.map((code) => ({
+        matter_id: matter.id,
+        jurisdiction_code: code,
+        jurisdiction_name: getJurisdictionName(code),
+      }))
+    );
+
+  if (jurisdictionError) {
+    return NextResponse.json({ error: "Failed to save jurisdictions" }, { status: 500 });
+  }
+
+  const { error: teamError } = await service
+    .from("matter_team")
+    .insert({ matter_id: matter.id, lawyer_id: lawyer.id, role: "lead" });
+
+  if (teamError) {
+    return NextResponse.json({ error: "Failed to add creator to team" }, { status: 500 });
+  }
+
+  // TODO: Trigger context generation — issue #15
+  // fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/context/generate`, {
+  //   method: "POST", body: JSON.stringify({ matter_id: matter.id })
+  // })
+
+  return NextResponse.json(matter, { status: 201 });
+}
+
+export async function GET(req: Request) {
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status");
+  const service = createServiceClient();
+
+  const { data: teamRows, error: teamError } = await service
+    .from("matter_team")
+    .select("matter_id")
+    .eq("lawyer_id", lawyer.id);
+
+  if (teamError) {
+    return NextResponse.json({ error: "Failed to load matters" }, { status: 500 });
+  }
+
+  const matterIds = (teamRows ?? []).map((r) => r.matter_id);
+  if (matterIds.length === 0) {
+    return NextResponse.json([]);
+  }
+
+  let query = service
+    .from("matters")
+    .select(`
+      id, title, client_name, matter_type, status, deadline, created_at,
+      matter_jurisdictions(jurisdiction_code, jurisdiction_name),
+      matter_team(lawyer_id)
+    `)
+    .in("id", matterIds)
+    .order("created_at", { ascending: false });
+
+  if (status) {
+    query = query.eq("status", status);
+  }
+
+  const { data: matters, error: mattersError } = await query;
+
+  if (mattersError) {
+    return NextResponse.json({ error: "Failed to load matters" }, { status: 500 });
+  }
+
+  return NextResponse.json(matters ?? []);
+}

--- a/lib/jurisdictions.ts
+++ b/lib/jurisdictions.ts
@@ -1,0 +1,31 @@
+const JURISDICTION_NAMES: Record<string, string> = {
+  AE: "United Arab Emirates",
+  AR: "Argentina",
+  AT: "Austria",
+  AU: "Australia",
+  BR: "Brazil",
+  CA: "Canada",
+  CN: "China",
+  CO: "Colombia",
+  DE: "Germany",
+  ES: "Spain",
+  EU: "European Union",
+  FR: "France",
+  GB: "United Kingdom",
+  HK: "Hong Kong",
+  IN: "India",
+  JP: "Japan",
+  KR: "South Korea",
+  MX: "Mexico",
+  MY: "Malaysia",
+  NL: "Netherlands",
+  PE: "Peru",
+  SA: "Saudi Arabia",
+  SG: "Singapore",
+  US: "United States",
+  ZA: "South Africa",
+};
+
+export function getJurisdictionName(code: string): string {
+  return JURISDICTION_NAMES[code.toUpperCase()] ?? code;
+}

--- a/lib/jurisdictions.ts
+++ b/lib/jurisdictions.ts
@@ -27,5 +27,6 @@ const JURISDICTION_NAMES: Record<string, string> = {
 };
 
 export function getJurisdictionName(code: string): string {
-  return JURISDICTION_NAMES[code.toUpperCase()] ?? code;
+  const normalized = code.trim().toUpperCase();
+  return JURISDICTION_NAMES[normalized] ?? normalized;
 }


### PR DESCRIPTION
## Summary
- `POST /api/matters` — Zod-validated creation, inserts matter + jurisdictions + creator as lead team member
- `GET /api/matters` — returns only matters the current user is on, supports `?status=` filter
- `GET /api/matters/[id]` — full detail with team members (with lawyer profiles), jurisdiction list, and brief statuses; 404 if user is not on the team
- `PATCH /api/matters/[id]` — update status or deadline, team membership enforced
- `lib/jurisdictions.ts` — jurisdiction code → name lookup for 25 jurisdictions used across the app

## Notes
- All routes use service client with explicit auth + ownership checks (seed data IDs don't match auth UIDs)
- Context generation trigger is stubbed with a TODO comment — wired in issue #15

Closes #10