### PR TITLE
Matter detail page with tab navigation and overview

### DIFF
--- a/app/matters/[id]/_components/MatterTabs.tsx
+++ b/app/matters/[id]/_components/MatterTabs.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { label: "Overview", segment: "overview" },
+  { label: "Context", segment: "context" },
+  { label: "Connect", segment: "connect" },
+  { label: "Flow", segment: "flow" },
+];
+
+export default function MatterTabs({ id }: { id: string }) {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex gap-0 -mb-px">
+      {TABS.map((tab) => {
+        const href = `/matters/${id}/${tab.segment}`;
+        const active = pathname === href || pathname.startsWith(href + "/");
+        return (
+          <Link
+            key={tab.segment}
+            href={href}
+            className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+              active
+                ? "border-brand-purple text-brand-purple"
+                : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            }`}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/matters/[id]/_lib/getMatter.ts
+++ b/app/matters/[id]/_lib/getMatter.ts
@@ -46,26 +46,27 @@ export const getMatterDetail = cache(async (id: string): Promise<MatterDetail | 
   } = await supabase.auth.getUser();
   if (!user) return null;
 
+  if (!user.email) return null;
   const service = createServiceClient();
 
-  const { data: lawyer } = await service
+  const { data: lawyer, error: lawyerError } = await service
     .from("lawyers")
     .select("id")
     .eq("email", user.email)
-    .single();
+    .maybeSingle();
 
-  if (!lawyer) return null;
+  if (lawyerError || !lawyer) return null;
 
-  const { data: membership } = await service
+  const { data: membership, error: membershipError } = await service
     .from("matter_team")
     .select("role")
     .eq("matter_id", id)
     .eq("lawyer_id", lawyer.id)
-    .single();
+    .maybeSingle();
 
-  if (!membership) return null;
+  if (membershipError || !membership) return null;
 
-  const { data: matter } = await service
+  const { data: matter, error: matterError } = await service
     .from("matters")
     .select(`
       id, title, description, client_name, matter_type, status, deadline, created_at,
@@ -77,7 +78,8 @@ export const getMatterDetail = cache(async (id: string): Promise<MatterDetail | 
       context_briefs(id, jurisdiction_code, jurisdiction_name, status)
     `)
     .eq("id", id)
-    .single();
+    .maybeSingle();
 
+  if (matterError) return null;
   return matter as unknown as MatterDetail | null;
 });

--- a/app/matters/[id]/_lib/getMatter.ts
+++ b/app/matters/[id]/_lib/getMatter.ts
@@ -1,0 +1,83 @@
+import { cache } from "react";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+
+export type MatterDetail = {
+  id: string;
+  title: string;
+  description: string;
+  client_name: string;
+  matter_type: string;
+  status: "active" | "completed" | "archived";
+  deadline: string | null;
+  created_at: string;
+  matter_jurisdictions: {
+    id: string;
+    jurisdiction_code: string;
+    jurisdiction_name: string;
+  }[];
+  matter_team: {
+    id: string;
+    role: "lead" | "collaborator" | "reviewer";
+    match_score: number | null;
+    joined_at: string;
+    lawyer: {
+      id: string;
+      full_name: string;
+      title: string;
+      office_city: string;
+      office_country: string;
+      reputation_score: number;
+      avatar_url: string | null;
+    } | null;
+  }[];
+  context_briefs: {
+    id: string;
+    jurisdiction_code: string;
+    jurisdiction_name: string;
+    status: "generating" | "ready" | "error";
+  }[];
+};
+
+// React cache deduplicates this call within the same request when layout + page both invoke it
+export const getMatterDetail = cache(async (id: string): Promise<MatterDetail | null> => {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const service = createServiceClient();
+
+  const { data: lawyer } = await service
+    .from("lawyers")
+    .select("id")
+    .eq("email", user.email)
+    .single();
+
+  if (!lawyer) return null;
+
+  const { data: membership } = await service
+    .from("matter_team")
+    .select("role")
+    .eq("matter_id", id)
+    .eq("lawyer_id", lawyer.id)
+    .single();
+
+  if (!membership) return null;
+
+  const { data: matter } = await service
+    .from("matters")
+    .select(`
+      id, title, description, client_name, matter_type, status, deadline, created_at,
+      matter_jurisdictions(id, jurisdiction_code, jurisdiction_name),
+      matter_team(
+        id, role, match_score, joined_at,
+        lawyer:lawyers(id, full_name, title, office_city, office_country, reputation_score, avatar_url)
+      ),
+      context_briefs(id, jurisdiction_code, jurisdiction_name, status)
+    `)
+    .eq("id", id)
+    .single();
+
+  return matter as unknown as MatterDetail | null;
+});

--- a/app/matters/[id]/connect/page.tsx
+++ b/app/matters/[id]/connect/page.tsx
@@ -1,0 +1,10 @@
+export default function ConnectPage() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <p className="text-sm font-medium text-gray-500">Lawyer matching</p>
+      <p className="text-xs text-gray-400 mt-1">
+        AI-ranked lawyer suggestions for each jurisdiction — coming in Phase 1
+      </p>
+    </div>
+  );
+}

--- a/app/matters/[id]/context/page.tsx
+++ b/app/matters/[id]/context/page.tsx
@@ -1,0 +1,10 @@
+export default function ContextPage() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <p className="text-sm font-medium text-gray-500">Context briefs</p>
+      <p className="text-xs text-gray-400 mt-1">
+        AI-generated jurisdiction intelligence — coming in Phase 1
+      </p>
+    </div>
+  );
+}

--- a/app/matters/[id]/flow/page.tsx
+++ b/app/matters/[id]/flow/page.tsx
@@ -1,0 +1,10 @@
+export default function FlowPage() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <p className="text-sm font-medium text-gray-500">Task flow</p>
+      <p className="text-xs text-gray-400 mt-1">
+        Cross-timezone task routing and handoffs — coming in Phase 2
+      </p>
+    </div>
+  );
+}

--- a/app/matters/[id]/layout.tsx
+++ b/app/matters/[id]/layout.tsx
@@ -1,0 +1,87 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, Calendar } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import Sidebar from "@/components/layout/Sidebar";
+import MatterTabs from "./_components/MatterTabs";
+import { getMatterDetail } from "./_lib/getMatter";
+
+const STATUS_STYLES: Record<string, string> = {
+  active: "bg-green-50 text-green-700 border-green-200",
+  completed: "bg-blue-50 text-blue-700 border-blue-200",
+  archived: "bg-gray-100 text-gray-500 border-gray-200",
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export default async function MatterLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { id: string };
+}) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const matter = await getMatterDetail(params.id);
+  if (!matter) notFound();
+
+  return (
+    <div className="flex min-h-screen bg-brand-grey-bg">
+      <Sidebar />
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Matter header */}
+        <div className="bg-white border-b border-brand-grey px-8 pt-7 pb-0">
+          <Link
+            href="/matters"
+            className="inline-flex items-center gap-1.5 text-xs text-gray-400 hover:text-brand-purple transition-colors mb-4"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" />
+            All matters
+          </Link>
+
+          <div className="mb-4">
+            <div className="flex items-center gap-3 mb-1">
+              <h1 className="text-xl font-bold text-gray-900">{matter.title}</h1>
+              <span
+                className={`text-[11px] font-medium px-2 py-0.5 rounded-full border ${
+                  STATUS_STYLES[matter.status] ?? STATUS_STYLES.active
+                }`}
+              >
+                {matter.status.charAt(0).toUpperCase() + matter.status.slice(1)}
+              </span>
+            </div>
+            <p className="text-sm text-gray-500">
+              {matter.client_name}
+              <span className="mx-2 text-gray-300">·</span>
+              {matter.matter_type}
+              {matter.deadline && (
+                <>
+                  <span className="mx-2 text-gray-300">·</span>
+                  <span className="inline-flex items-center gap-1">
+                    <Calendar className="w-3.5 h-3.5" />
+                    Due {formatDate(matter.deadline)}
+                  </span>
+                </>
+              )}
+            </p>
+          </div>
+
+          <MatterTabs id={params.id} />
+        </div>
+
+        <main className="flex-1 p-8">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/matters/[id]/overview/page.tsx
+++ b/app/matters/[id]/overview/page.tsx
@@ -4,12 +4,13 @@ import Link from "next/link";
 import { getMatterDetail, type MatterDetail } from "../_lib/getMatter";
 
 function Initials({ name }: { name: string }) {
-  const parts = name.trim().split(" ");
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return <>?</>;
   return (
     <>
       {parts.length >= 2
         ? `${parts[0][0]}${parts[parts.length - 1][0]}`
-        : name[0]}
+        : parts[0][0]}
     </>
   );
 }

--- a/app/matters/[id]/overview/page.tsx
+++ b/app/matters/[id]/overview/page.tsx
@@ -1,0 +1,177 @@
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import { getMatterDetail, type MatterDetail } from "../_lib/getMatter";
+
+function Initials({ name }: { name: string }) {
+  const parts = name.trim().split(" ");
+  return (
+    <>
+      {parts.length >= 2
+        ? `${parts[0][0]}${parts[parts.length - 1][0]}`
+        : name[0]}
+    </>
+  );
+}
+
+const ROLE_STYLES: Record<string, string> = {
+  lead: "bg-brand-purple/10 text-brand-purple border-brand-purple/20",
+  collaborator: "bg-blue-50 text-blue-700 border-blue-200",
+  reviewer: "bg-gray-100 text-gray-500 border-gray-200",
+};
+
+type TeamMember = MatterDetail["matter_team"][number];
+
+function TeamMemberCard({ member }: { member: TeamMember }) {
+  const lawyer = member.lawyer;
+  if (!lawyer) return null;
+
+  return (
+    <Link
+      href={`/lawyers/${lawyer.id}`}
+      className="flex items-center gap-3 p-4 bg-white border border-brand-grey rounded-xl hover:border-brand-purple hover:shadow-sm transition-all group"
+    >
+      <div className="w-10 h-10 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
+        {lawyer.avatar_url ? (
+          <Image
+            src={lawyer.avatar_url}
+            alt={lawyer.full_name}
+            width={40}
+            height={40}
+            className="rounded-full object-cover"
+          />
+        ) : (
+          <span className="text-brand-purple font-semibold text-sm">
+            <Initials name={lawyer.full_name} />
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-gray-900 group-hover:text-brand-purple transition-colors truncate">
+          {lawyer.full_name}
+        </p>
+        <p className="text-xs text-gray-500 truncate">{lawyer.title}</p>
+        <p className="text-xs text-gray-400">
+          {lawyer.office_city}, {lawyer.office_country}
+        </p>
+      </div>
+
+      <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
+        <span
+          className={`text-[11px] font-medium px-2 py-0.5 rounded-full border ${
+            ROLE_STYLES[member.role] ?? ROLE_STYLES.collaborator
+          }`}
+        >
+          {member.role.charAt(0).toUpperCase() + member.role.slice(1)}
+        </span>
+        <span className="text-[11px] text-gray-400">
+          {lawyer.reputation_score.toLocaleString()} pts
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+export default async function MatterOverviewPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const matter = await getMatterDetail(params.id);
+  if (!matter) notFound();
+
+  const readyBriefs = matter.context_briefs.filter((b) => b.status === "ready").length;
+  const totalBriefs = matter.context_briefs.length;
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {/* Description */}
+      {matter.description && (
+        <section>
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Description
+          </h2>
+          <div className="bg-white border border-brand-grey rounded-xl p-5">
+            <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
+              {matter.description}
+            </p>
+          </div>
+        </section>
+      )}
+
+      {/* Jurisdictions */}
+      <section>
+        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          Jurisdictions
+          <span className="ml-2 normal-case font-normal text-gray-400">
+            ({matter.matter_jurisdictions.length})
+          </span>
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {matter.matter_jurisdictions.map((j) => (
+            <div
+              key={j.id}
+              className="flex items-center gap-2 px-3 py-2 bg-white border border-brand-grey rounded-lg text-sm text-gray-700"
+            >
+              <span>{j.jurisdiction_name}</span>
+              <span className="text-xs text-gray-400">{j.jurisdiction_code}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Context briefs summary */}
+      {totalBriefs > 0 && (
+        <section>
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Context briefs
+          </h2>
+          <div className="bg-white border border-brand-grey rounded-xl p-5 flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-900">
+                {readyBriefs} of {totalBriefs} brief{totalBriefs !== 1 ? "s" : ""} ready
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">
+                AI-generated jurisdiction intelligence
+              </p>
+            </div>
+            <Link
+              href={`/matters/${matter.id}/context`}
+              className="text-sm text-brand-purple font-medium hover:underline"
+            >
+              View all →
+            </Link>
+          </div>
+        </section>
+      )}
+
+      {/* Team */}
+      <section>
+        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          Team
+          <span className="ml-2 normal-case font-normal text-gray-400">
+            ({matter.matter_team.length} member{matter.matter_team.length !== 1 ? "s" : ""})
+          </span>
+        </h2>
+        <div className="space-y-2">
+          {matter.matter_team.map((member) => (
+            <TeamMemberCard key={member.id} member={member} />
+          ))}
+        </div>
+      </section>
+
+      {/* Metadata */}
+      <section className="text-xs text-gray-400 border-t border-brand-grey pt-4">
+        Matter ID: <span className="font-mono">{matter.id}</span>
+        <span className="mx-2">·</span>
+        Created{" "}
+        {new Date(matter.created_at).toLocaleDateString("en-GB", {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        })}
+      </section>
+    </div>
+  );
+}

--- a/app/matters/[id]/page.tsx
+++ b/app/matters/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MatterPage({ params }: { params: { id: string } }) {
+  redirect(`/matters/${params.id}/overview`);
+}


### PR DESCRIPTION
## Summary
- Adds `app/matters/[id]/layout.tsx` — shared matter header (title, status badge, client, matter type, deadline) + tab nav, with auth and team membership check
- Adds `_lib/getMatter.ts` — React `cache()`-wrapped fetch deduplicates the Supabase call between layout and page within the same request
- Adds `_components/MatterTabs.tsx` — client tab nav using `usePathname()` for active state across Overview / Context / Connect / Flow
- Adds `overview/page.tsx` — description, jurisdiction chips, context briefs summary (ready/total), team member cards (avatar, role badge, reputation, links to lawyer profile)
- `page.tsx` redirects `/matters/[id]` → `/matters/[id]/overview`
- Context / Connect / Flow pages are placeholders (will be filled in subsequent issues)

## Test plan
- [ ] Create a matter → redirected to `/matters/{id}/context` → placeholder shown, tab nav visible
- [ ] Click Overview tab → description, jurisdictions, team render correctly
- [ ] Matter with no description — description section hidden
- [ ] Team member cards link to `/lawyers/{id}`
- [ ] Back arrow → `/matters` list
- [ ] Status badge correct colour: green=active, blue=completed, grey=archived
- [ ] Deadline shown in header when set; absent when not
- [ ] Non-team member URL → 404 page
- [ ] Unauthenticated visit → `/login`

Closes #13