### PR TITLE
Context generation API with parallel Groq calls

### DIFF
--- a/app/api/context/generate/route.ts
+++ b/app/api/context/generate/route.ts
@@ -12,15 +12,16 @@ async function getAuthenticatedLawyer() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) return null;
+  if (!user?.email) return null;
 
   const service = createServiceClient();
-  const { data: lawyer } = await service
+  const { data: lawyer, error } = await service
     .from("lawyers")
     .select("id, email")
     .eq("email", user.email)
-    .single();
+    .maybeSingle();
 
+  if (error) return null;
   return lawyer;
 }
 
@@ -49,14 +50,14 @@ export async function POST(req: Request) {
   const service = createServiceClient();
 
   // Verify team membership
-  const { data: membership } = await service
+  const { data: membership, error: membershipError } = await service
     .from("matter_team")
     .select("role")
     .eq("matter_id", matter_id)
     .eq("lawyer_id", lawyer.id)
-    .single();
+    .maybeSingle();
 
-  if (!membership) {
+  if (membershipError || !membership) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
@@ -81,10 +82,14 @@ export async function POST(req: Request) {
   }
 
   // Fetch existing briefs to determine what needs generation
-  const { data: existing } = await service
+  const { data: existing, error: existingError } = await service
     .from("context_briefs")
     .select("id, jurisdiction_code, status")
     .eq("matter_id", matter_id);
+
+  if (existingError) {
+    return NextResponse.json({ error: "Failed to check existing briefs" }, { status: 500 });
+  }
 
   const existingByCode = new Map(
     (existing ?? []).map((b) => [b.jurisdiction_code, b])
@@ -120,10 +125,11 @@ export async function POST(req: Request) {
 
     prepOps.push(
       (async () => {
-        await service
+        const { error } = await service
           .from("context_briefs")
           .update({ status: "generating", legal_landscape: null, cultural_intelligence: null, regulatory_notes: null })
           .in("id", updateIds);
+        if (error) throw new Error(`Failed to reset errored briefs: ${error.message}`);
       })()
     );
   }
@@ -131,7 +137,7 @@ export async function POST(req: Request) {
   if (toInsert.length > 0) {
     prepOps.push(
       (async () => {
-        await service.from("context_briefs").insert(
+        const { error } = await service.from("context_briefs").insert(
           toInsert.map((j) => ({
             matter_id,
             jurisdiction_code: j.jurisdiction_code,
@@ -139,14 +145,22 @@ export async function POST(req: Request) {
             status: "generating",
           }))
         );
+        if (error) throw new Error(`Failed to create brief stubs: ${error.message}`);
       })()
     );
   }
 
-  await Promise.all(prepOps);
+  try {
+    await Promise.all(prepOps);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to initialise briefs" },
+      { status: 500 }
+    );
+  }
 
   // Re-fetch brief IDs so we can update by id after generation
-  const { data: freshStubs } = await service
+  const { data: freshStubs, error: stubsError } = await service
     .from("context_briefs")
     .select("id, jurisdiction_code")
     .eq("matter_id", matter_id)
@@ -155,9 +169,18 @@ export async function POST(req: Request) {
       toGenerate.map((j) => j.jurisdiction_code)
     );
 
+  if (stubsError) {
+    return NextResponse.json({ error: "Failed to retrieve brief IDs" }, { status: 500 });
+  }
+
   const briefIdByCode = new Map(
     (freshStubs ?? []).map((b) => [b.jurisdiction_code, b.id])
   );
+
+  const missingIds = toGenerate.filter((j) => !briefIdByCode.has(j.jurisdiction_code));
+  if (missingIds.length > 0) {
+    return NextResponse.json({ error: "Brief IDs missing after insert" }, { status: 500 });
+  }
 
   // Run all Groq calls in parallel
   const genResults = await Promise.allSettled(
@@ -179,7 +202,7 @@ export async function POST(req: Request) {
       if (!briefId) return;
 
       if (result.status === "fulfilled") {
-        await service
+        const { error } = await service
           .from("context_briefs")
           .update({
             status: "ready",
@@ -188,11 +211,13 @@ export async function POST(req: Request) {
             regulatory_notes: result.value.content.regulatory_notes,
           })
           .eq("id", briefId);
+        if (error) throw new Error(`DB update failed for brief ${briefId}: ${error.message}`);
       } else {
-        await service
+        const { error } = await service
           .from("context_briefs")
           .update({ status: "error" })
           .eq("id", briefId);
+        if (error) throw new Error(`DB error-mark failed for brief ${briefId}: ${error.message}`);
       }
     })
   );

--- a/app/api/context/generate/route.ts
+++ b/app/api/context/generate/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { generateBrief } from "@/lib/ai/groq";
+
+const schema = z.object({
+  matter_id: z.string().uuid(),
+});
+
+async function getAuthenticatedLawyer() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const service = createServiceClient();
+  const { data: lawyer } = await service
+    .from("lawyers")
+    .select("id, email")
+    .eq("email", user.email)
+    .single();
+
+  return lawyer;
+}
+
+export async function POST(req: Request) {
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const { matter_id } = parsed.data;
+  const service = createServiceClient();
+
+  // Verify team membership
+  const { data: membership } = await service
+    .from("matter_team")
+    .select("role")
+    .eq("matter_id", matter_id)
+    .eq("lawyer_id", lawyer.id)
+    .single();
+
+  if (!membership) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Fetch matter with jurisdictions
+  const { data: matter, error: matterError } = await service
+    .from("matters")
+    .select("id, matter_type, description, matter_jurisdictions(jurisdiction_code, jurisdiction_name)")
+    .eq("id", matter_id)
+    .single();
+
+  if (matterError || !matter) {
+    return NextResponse.json({ error: "Matter not found" }, { status: 404 });
+  }
+
+  const jurisdictions = matter.matter_jurisdictions as {
+    jurisdiction_code: string;
+    jurisdiction_name: string;
+  }[];
+
+  if (jurisdictions.length === 0) {
+    return NextResponse.json({ briefs: [] });
+  }
+
+  // Fetch existing briefs to determine what needs generation
+  const { data: existing } = await service
+    .from("context_briefs")
+    .select("id, jurisdiction_code, status")
+    .eq("matter_id", matter_id);
+
+  const existingByCode = new Map(
+    (existing ?? []).map((b) => [b.jurisdiction_code, b])
+  );
+
+  // Skip jurisdictions already ready or currently generating
+  const toGenerate = jurisdictions.filter((j) => {
+    const brief = existingByCode.get(j.jurisdiction_code);
+    return !brief || brief.status === "error";
+  });
+
+  if (toGenerate.length === 0) {
+    // Nothing to do — return current briefs
+    const { data: briefs } = await service
+      .from("context_briefs")
+      .select("id, jurisdiction_code, jurisdiction_name, status, legal_landscape, cultural_intelligence, regulatory_notes, created_at")
+      .eq("matter_id", matter_id)
+      .order("jurisdiction_code");
+
+    return NextResponse.json({ briefs: briefs ?? [] });
+  }
+
+  // Mark each as generating: update existing "error" rows, insert new ones
+  const toUpdate = toGenerate.filter((j) => existingByCode.has(j.jurisdiction_code));
+  const toInsert = toGenerate.filter((j) => !existingByCode.has(j.jurisdiction_code));
+
+  const prepOps: Promise<void>[] = [];
+
+  if (toUpdate.length > 0) {
+    const updateIds = toUpdate
+      .map((j) => existingByCode.get(j.jurisdiction_code)?.id)
+      .filter(Boolean) as string[];
+
+    prepOps.push(
+      (async () => {
+        await service
+          .from("context_briefs")
+          .update({ status: "generating", legal_landscape: null, cultural_intelligence: null, regulatory_notes: null })
+          .in("id", updateIds);
+      })()
+    );
+  }
+
+  if (toInsert.length > 0) {
+    prepOps.push(
+      (async () => {
+        await service.from("context_briefs").insert(
+          toInsert.map((j) => ({
+            matter_id,
+            jurisdiction_code: j.jurisdiction_code,
+            jurisdiction_name: j.jurisdiction_name,
+            status: "generating",
+          }))
+        );
+      })()
+    );
+  }
+
+  await Promise.all(prepOps);
+
+  // Re-fetch brief IDs so we can update by id after generation
+  const { data: freshStubs } = await service
+    .from("context_briefs")
+    .select("id, jurisdiction_code")
+    .eq("matter_id", matter_id)
+    .in(
+      "jurisdiction_code",
+      toGenerate.map((j) => j.jurisdiction_code)
+    );
+
+  const briefIdByCode = new Map(
+    (freshStubs ?? []).map((b) => [b.jurisdiction_code, b.id])
+  );
+
+  // Run all Groq calls in parallel
+  const genResults = await Promise.allSettled(
+    toGenerate.map((j) =>
+      generateBrief({
+        matterType: matter.matter_type,
+        jurisdictionCode: j.jurisdiction_code,
+        jurisdictionName: j.jurisdiction_name,
+        description: matter.description ?? undefined,
+      }).then((content) => ({ jurisdiction_code: j.jurisdiction_code, content }))
+    )
+  );
+
+  // Persist results — parallel updates
+  await Promise.allSettled(
+    genResults.map(async (result, i) => {
+      const code = toGenerate[i].jurisdiction_code;
+      const briefId = briefIdByCode.get(code);
+      if (!briefId) return;
+
+      if (result.status === "fulfilled") {
+        await service
+          .from("context_briefs")
+          .update({
+            status: "ready",
+            legal_landscape: result.value.content.legal_landscape,
+            cultural_intelligence: result.value.content.cultural_intelligence,
+            regulatory_notes: result.value.content.regulatory_notes,
+          })
+          .eq("id", briefId);
+      } else {
+        await service
+          .from("context_briefs")
+          .update({ status: "error" })
+          .eq("id", briefId);
+      }
+    })
+  );
+
+  // Return all briefs for this matter
+  const { data: briefs, error: briefsError } = await service
+    .from("context_briefs")
+    .select("id, jurisdiction_code, jurisdiction_name, status, legal_landscape, cultural_intelligence, regulatory_notes, created_at")
+    .eq("matter_id", matter_id)
+    .order("jurisdiction_code");
+
+  if (briefsError) {
+    return NextResponse.json({ error: "Failed to load briefs" }, { status: 500 });
+  }
+
+  return NextResponse.json({ briefs: briefs ?? [] });
+}

--- a/app/api/matters/route.ts
+++ b/app/api/matters/route.ts
@@ -97,10 +97,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Failed to add creator to team" }, { status: 500 });
   }
 
-  // TODO: Trigger context generation — issue #15
-  // fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/context/generate`, {
-  //   method: "POST", body: JSON.stringify({ matter_id: matter.id })
-  // })
+  // Context briefs are generated on demand from the Context tab UI via
+  // POST /api/context/generate (issue #15). Not triggered here because
+  // fire-and-forget is unreliable on Vercel Hobby (no waitUntil).
 
   return NextResponse.json(matter, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/context/generate` — accepts `{ matter_id }`, verifies team membership, and runs `generateBrief()` in parallel for all jurisdictions that don't already have a "ready" brief
- Idempotent: skips jurisdictions already "ready" or "generating"; retries any that previously "error"ed
- Two-phase: marks all target jurisdictions as "generating" first, then runs `Promise.allSettled` for Groq calls so one failure doesn't block others
- Returns the full brief set for the matter after all updates complete
- Updates the TODO comment in `/api/matters/route.ts` — generation is triggered from the Context tab UI (issue #17) rather than fire-and-forget on creation (unreliable on Vercel Hobby without `waitUntil`)

## Design notes
- `Promise.allSettled` ensures partial success: if 2 of 5 Groq calls fail, 3 briefs are saved as "ready" and 2 as "error"
- Errored briefs can be retried by calling the endpoint again
- Vercel timeout risk: parallel Groq calls for ~4 jurisdictions typically complete in 5–8 s; 8 jurisdictions could push close to the Hobby 10 s limit — documented as known risk

## Test plan
- [ ] Set `GROQ_API_KEY`, create a 2-jurisdiction matter, call `POST /api/context/generate` — both briefs return with `status: "ready"` and non-empty content fields
- [ ] Call again — returns same briefs without re-generating (idempotent)
- [ ] Manually set a brief to `status: "error"`, call again — only that brief is regenerated
- [ ] Call with a `matter_id` the user is not on — returns 404
- [ ] Call without auth — returns 401
- [ ] Invalid UUID for `matter_id` — returns 400 with validation details

Closes #15