### PR TITLE
Context tab UI with live brief generation and polling

### DIFF
--- a/app/matters/[id]/context/_components/BriefCard.tsx
+++ b/app/matters/[id]/context/_components/BriefCard.tsx
@@ -25,11 +25,13 @@ const SECTIONS: { key: keyof Brief; label: string; color: string }[] = [
 ];
 
 function Section({
+  sectionId,
   label,
   color,
   content,
   defaultOpen,
 }: {
+  sectionId: string;
   label: string;
   color: string;
   content: string;
@@ -41,6 +43,8 @@ function Section({
     <div className={`border-l-2 ${color} pl-4`}>
       <button
         type="button"
+        aria-expanded={open}
+        aria-controls={sectionId}
         onClick={() => setOpen((v) => !v)}
         className="flex items-center justify-between w-full text-left"
       >
@@ -53,11 +57,11 @@ function Section({
           <ChevronDown className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
         )}
       </button>
-      {open && (
+      <div id={sectionId} hidden={!open}>
         <p className="mt-2 text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
           {content}
         </p>
-      )}
+      </div>
     </div>
   );
 }
@@ -92,6 +96,7 @@ export default function BriefCard({ brief }: { brief: Brief }) {
         return (
           <Section
             key={s.key}
+            sectionId={`brief-${brief.id}-${s.key}`}
             label={s.label}
             color={s.color}
             content={content}

--- a/app/matters/[id]/context/_components/BriefCard.tsx
+++ b/app/matters/[id]/context/_components/BriefCard.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { JURISDICTIONS } from "@/lib/jurisdictions";
+
+export type Brief = {
+  id: string;
+  jurisdiction_code: string;
+  jurisdiction_name: string;
+  status: "generating" | "ready" | "error";
+  legal_landscape: string | null;
+  cultural_intelligence: string | null;
+  regulatory_notes: string | null;
+};
+
+function getFlag(code: string): string {
+  return JURISDICTIONS.find((j) => j.code === code)?.flag ?? "";
+}
+
+const SECTIONS: { key: keyof Brief; label: string; color: string }[] = [
+  { key: "legal_landscape", label: "Legal Landscape", color: "border-brand-purple/40" },
+  { key: "cultural_intelligence", label: "Cultural Intelligence", color: "border-blue-300" },
+  { key: "regulatory_notes", label: "Regulatory Notes", color: "border-green-300" },
+];
+
+function Section({
+  label,
+  color,
+  content,
+  defaultOpen,
+}: {
+  label: string;
+  color: string;
+  content: string;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className={`border-l-2 ${color} pl-4`}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center justify-between w-full text-left"
+      >
+        <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
+          {label}
+        </span>
+        {open ? (
+          <ChevronUp className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+        ) : (
+          <ChevronDown className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+        )}
+      </button>
+      {open && (
+        <p className="mt-2 text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
+          {content}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function BriefCard({ brief }: { brief: Brief }) {
+  const flag = getFlag(brief.jurisdiction_code);
+
+  return (
+    <div className="bg-white border border-brand-grey rounded-xl p-6 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl" aria-hidden="true">
+            {flag}
+          </span>
+          <div>
+            <p className="text-sm font-semibold text-gray-900">
+              {brief.jurisdiction_name}
+            </p>
+            <p className="text-xs text-gray-400">{brief.jurisdiction_code}</p>
+          </div>
+        </div>
+        <span className="text-[11px] font-medium px-2 py-0.5 rounded-full border bg-green-50 text-green-700 border-green-200">
+          Ready
+        </span>
+      </div>
+
+      {/* Content sections */}
+      {SECTIONS.map((s, i) => {
+        const content = brief[s.key] as string | null;
+        if (!content) return null;
+        return (
+          <Section
+            key={s.key}
+            label={s.label}
+            color={s.color}
+            content={content}
+            defaultOpen={i === 0}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/app/matters/[id]/context/_components/BriefSkeleton.tsx
+++ b/app/matters/[id]/context/_components/BriefSkeleton.tsx
@@ -1,0 +1,36 @@
+import { Loader2 } from "lucide-react";
+
+export default function BriefSkeleton({ jurisdictionName }: { jurisdictionName: string }) {
+  return (
+    <div className="bg-white border border-brand-grey rounded-xl p-6 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-gray-100 animate-pulse" />
+          <div>
+            <p className="text-sm font-semibold text-gray-900">{jurisdictionName}</p>
+            <p className="text-xs text-gray-400 flex items-center gap-1 mt-0.5">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              Generating intelligence brief…
+            </p>
+          </div>
+        </div>
+        <span className="text-[11px] font-medium px-2 py-0.5 rounded-full border bg-amber-50 text-amber-600 border-amber-200">
+          Generating
+        </span>
+      </div>
+
+      {/* Skeleton lines */}
+      {[["w-full", "w-5/6", "w-4/5"], ["w-full", "w-3/4"], ["w-full", "w-5/6", "w-2/3"]].map(
+        (lines, sectionIdx) => (
+          <div key={sectionIdx} className="space-y-2 pt-3 border-t border-gray-100">
+            <div className="h-2.5 bg-gray-200 rounded animate-pulse w-32" />
+            {lines.map((w, i) => (
+              <div key={i} className={`h-2 bg-gray-100 rounded animate-pulse ${w}`} />
+            ))}
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/app/matters/[id]/context/_components/ContextTab.tsx
+++ b/app/matters/[id]/context/_components/ContextTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { RefreshCw, AlertCircle, Sparkles } from "lucide-react";
+import { RefreshCw, AlertCircle, Sparkles, XCircle } from "lucide-react";
 import BriefCard, { type Brief } from "./BriefCard";
 import BriefSkeleton from "./BriefSkeleton";
 
@@ -13,6 +13,8 @@ type Props = {
   jurisdictions: Jurisdiction[];
 };
 
+const POLL_TIMEOUT_MS = 60_000;
+
 export default function ContextTab({ matterId, initialBriefs, jurisdictions }: Props) {
   const [briefs, setBriefs] = useState<Brief[]>(initialBriefs);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -20,6 +22,8 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
   const autoTriggered = useRef(false);
   const briefsRef = useRef(briefs);
   briefsRef.current = briefs;
+  const stopPolling = useRef(false);
+  const pollingStartedAt = useRef<number | null>(null);
 
   // Auto-trigger generation if no briefs yet
   useEffect(() => {
@@ -30,19 +34,55 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Poll generating briefs (handles page-refresh-mid-generation case)
-  const hasGenerating = briefs.some((b) => b.status === "generating");
+  // Poll real generating briefs (handles page-refresh-mid-generation; skip optimistic pending- stubs)
+  const hasGenerating = briefs.some(
+    (b) => b.status === "generating" && !b.id.startsWith("pending-")
+  );
   useEffect(() => {
-    if (!hasGenerating) return;
+    if (!hasGenerating) {
+      pollingStartedAt.current = null;
+      return;
+    }
+
+    stopPolling.current = false;
+    if (!pollingStartedAt.current) {
+      pollingStartedAt.current = Date.now();
+    }
 
     const interval = setInterval(async () => {
-      const generating = briefsRef.current.filter((b) => b.status === "generating");
+      if (stopPolling.current) return;
+
+      // Timeout: if generating for >60 s, mark remaining as error in UI
+      if (pollingStartedAt.current && Date.now() - pollingStartedAt.current > POLL_TIMEOUT_MS) {
+        setBriefs((prev) =>
+          prev.map((b) =>
+            b.status === "generating" && !b.id.startsWith("pending-")
+              ? { ...b, status: "error" as const }
+              : b
+          )
+        );
+        return;
+      }
+
+      const generating = briefsRef.current.filter(
+        (b) => b.status === "generating" && !b.id.startsWith("pending-")
+      );
       if (generating.length === 0) return;
 
       const updates = await Promise.allSettled(
-        generating.map((b) =>
-          fetch(`/api/context/${b.id}`, { cache: "no-store" }).then((r) => r.json())
-        )
+        generating.map(async (b) => {
+          const res = await fetch(`/api/context/${b.id}`, { cache: "no-store" });
+          if (res.redirected) {
+            stopPolling.current = true;
+            setError("Your session expired. Please refresh the page to continue.");
+            throw new Error("session-expired");
+          }
+          const ct = res.headers.get("content-type") ?? "";
+          if (!res.ok || !ct.includes("application/json")) {
+            throw new Error(`Unexpected response: HTTP ${res.status}`);
+          }
+          return res.json() as Promise<Brief>;
+        })
       );
 
       setBriefs((prev) => {
@@ -50,28 +90,31 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
         updates.forEach((result, i) => {
           if (result.status === "fulfilled" && result.value?.id) {
             const idx = next.findIndex((b) => b.id === generating[i].id);
-            if (idx !== -1) next[idx] = result.value as Brief;
+            if (idx !== -1) next[idx] = result.value;
           }
         });
         return next;
       });
     }, 2500);
 
-    return () => clearInterval(interval);
+    return () => {
+      stopPolling.current = true;
+      clearInterval(interval);
+    };
   }, [hasGenerating]);
 
   async function handleGenerate() {
     setIsGenerating(true);
     setError(null);
 
-    // Show skeletons immediately for any jurisdiction that doesn't have a ready brief
+    // Optimistic skeletons for pending jurisdictions (stable order preserved by render logic)
     const readyCodes = new Set(
       briefs.filter((b) => b.status === "ready").map((b) => b.jurisdiction_code)
     );
     const pending = jurisdictions.filter((j) => !readyCodes.has(j.jurisdiction_code));
 
     if (pending.length > 0) {
-      const skeletonPlaceholders: Brief[] = pending.map((j) => ({
+      const stubs: Brief[] = pending.map((j) => ({
         id: `pending-${j.jurisdiction_code}`,
         jurisdiction_code: j.jurisdiction_code,
         jurisdiction_name: j.jurisdiction_name,
@@ -80,10 +123,10 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
         cultural_intelligence: null,
         regulatory_notes: null,
       }));
-      setBriefs((prev) => {
-        const existing = prev.filter((b) => b.status === "ready");
-        return [...existing, ...skeletonPlaceholders];
-      });
+      setBriefs((prev) => [
+        ...prev.filter((b) => b.status === "ready"),
+        ...stubs,
+      ]);
     }
 
     try {
@@ -93,36 +136,39 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
         body: JSON.stringify({ matter_id: matterId }),
       });
 
-      const contentType = res.headers.get("content-type") ?? "";
-      if (!contentType.includes("application/json")) {
+      if (res.redirected) {
+        setError("Your session expired. Please refresh the page to log in.");
+        setBriefs((prev) => prev.filter((b) => !b.id.startsWith("pending-")));
+        return;
+      }
+
+      const ct = res.headers.get("content-type") ?? "";
+      if (!ct.includes("application/json")) {
         throw new Error("Unexpected server response");
       }
 
       const data = await res.json();
-
-      if (!res.ok) {
-        throw new Error(data.error ?? "Failed to generate briefs");
-      }
+      if (!res.ok) throw new Error(data.error ?? "Failed to generate briefs");
 
       setBriefs(data.briefs as Brief[]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
-      // Remove skeleton placeholders on error
       setBriefs((prev) => prev.filter((b) => !b.id.startsWith("pending-")));
     } finally {
       setIsGenerating(false);
     }
   }
 
-  const readyBriefs = briefs.filter((b) => b.status === "ready");
-  const generatingBriefs = briefs.filter((b) => b.status === "generating");
+  const briefByCode = new Map(briefs.map((b) => [b.jurisdiction_code, b]));
   const errorBriefs = briefs.filter((b) => b.status === "error");
   const hasErrors = errorBriefs.length > 0;
-  const allDone = briefs.length > 0 && generatingBriefs.length === 0;
+  const allDone =
+    briefs.length > 0 &&
+    !briefs.some((b) => b.status === "generating");
 
   return (
     <div className="max-w-3xl space-y-6">
-      {/* Header row */}
+      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-sm font-semibold text-gray-900">
@@ -132,7 +178,6 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
             AI-generated legal landscape, cultural context, and regulatory notes per jurisdiction
           </p>
         </div>
-
         {allDone && (
           <button
             type="button"
@@ -146,7 +191,7 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
         )}
       </div>
 
-      {/* Server / network error */}
+      {/* Error banner */}
       {error && (
         <div className="flex items-start gap-2 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">
           <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
@@ -154,7 +199,7 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
         </div>
       )}
 
-      {/* Empty state (before auto-trigger fires) */}
+      {/* Empty / preparing state */}
       {briefs.length === 0 && !isGenerating && (
         <div className="flex flex-col items-center justify-center py-20 text-center">
           <Sparkles className="w-8 h-8 text-brand-purple/40 mb-3" />
@@ -165,7 +210,7 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
         </div>
       )}
 
-      {/* Error retries banner */}
+      {/* Retry banner */}
       {hasErrors && allDone && (
         <div className="flex items-center justify-between px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
           <p className="text-sm text-amber-700">
@@ -181,15 +226,37 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
         </div>
       )}
 
-      {/* Generating skeletons */}
-      {generatingBriefs.map((b) => (
-        <BriefSkeleton key={b.id} jurisdictionName={b.jurisdiction_name} />
-      ))}
+      {/* Stable ordered list — each slot rendered in jurisdiction order */}
+      {jurisdictions.map((j) => {
+        const brief = briefByCode.get(j.jurisdiction_code);
 
-      {/* Ready briefs */}
-      {readyBriefs.map((b) => (
-        <BriefCard key={b.id} brief={b} />
-      ))}
+        if (brief?.status === "ready") {
+          return <BriefCard key={j.jurisdiction_code} brief={brief} />;
+        }
+
+        if (brief?.status === "error") {
+          return (
+            <div
+              key={j.jurisdiction_code}
+              className="flex items-center gap-3 bg-white border border-red-200 rounded-xl px-5 py-4"
+            >
+              <XCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
+              <p className="text-sm text-gray-600">
+                <span className="font-medium">{j.jurisdiction_name}</span> — brief generation failed
+              </p>
+            </div>
+          );
+        }
+
+        // Generating (real or optimistic stub) or no brief yet during active generation
+        if (isGenerating || brief?.status === "generating") {
+          return (
+            <BriefSkeleton key={j.jurisdiction_code} jurisdictionName={j.jurisdiction_name} />
+          );
+        }
+
+        return null;
+      })}
     </div>
   );
 }

--- a/app/matters/[id]/context/_components/ContextTab.tsx
+++ b/app/matters/[id]/context/_components/ContextTab.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { RefreshCw, AlertCircle, Sparkles } from "lucide-react";
+import BriefCard, { type Brief } from "./BriefCard";
+import BriefSkeleton from "./BriefSkeleton";
+
+type Jurisdiction = { jurisdiction_code: string; jurisdiction_name: string };
+
+type Props = {
+  matterId: string;
+  initialBriefs: Brief[];
+  jurisdictions: Jurisdiction[];
+};
+
+export default function ContextTab({ matterId, initialBriefs, jurisdictions }: Props) {
+  const [briefs, setBriefs] = useState<Brief[]>(initialBriefs);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const autoTriggered = useRef(false);
+  const briefsRef = useRef(briefs);
+  briefsRef.current = briefs;
+
+  // Auto-trigger generation if no briefs yet
+  useEffect(() => {
+    if (briefs.length === 0 && !autoTriggered.current) {
+      autoTriggered.current = true;
+      void handleGenerate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Poll generating briefs (handles page-refresh-mid-generation case)
+  const hasGenerating = briefs.some((b) => b.status === "generating");
+  useEffect(() => {
+    if (!hasGenerating) return;
+
+    const interval = setInterval(async () => {
+      const generating = briefsRef.current.filter((b) => b.status === "generating");
+      if (generating.length === 0) return;
+
+      const updates = await Promise.allSettled(
+        generating.map((b) =>
+          fetch(`/api/context/${b.id}`, { cache: "no-store" }).then((r) => r.json())
+        )
+      );
+
+      setBriefs((prev) => {
+        const next = [...prev];
+        updates.forEach((result, i) => {
+          if (result.status === "fulfilled" && result.value?.id) {
+            const idx = next.findIndex((b) => b.id === generating[i].id);
+            if (idx !== -1) next[idx] = result.value as Brief;
+          }
+        });
+        return next;
+      });
+    }, 2500);
+
+    return () => clearInterval(interval);
+  }, [hasGenerating]);
+
+  async function handleGenerate() {
+    setIsGenerating(true);
+    setError(null);
+
+    // Show skeletons immediately for any jurisdiction that doesn't have a ready brief
+    const readyCodes = new Set(
+      briefs.filter((b) => b.status === "ready").map((b) => b.jurisdiction_code)
+    );
+    const pending = jurisdictions.filter((j) => !readyCodes.has(j.jurisdiction_code));
+
+    if (pending.length > 0) {
+      const skeletonPlaceholders: Brief[] = pending.map((j) => ({
+        id: `pending-${j.jurisdiction_code}`,
+        jurisdiction_code: j.jurisdiction_code,
+        jurisdiction_name: j.jurisdiction_name,
+        status: "generating",
+        legal_landscape: null,
+        cultural_intelligence: null,
+        regulatory_notes: null,
+      }));
+      setBriefs((prev) => {
+        const existing = prev.filter((b) => b.status === "ready");
+        return [...existing, ...skeletonPlaceholders];
+      });
+    }
+
+    try {
+      const res = await fetch("/api/context/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ matter_id: matterId }),
+      });
+
+      const contentType = res.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        throw new Error("Unexpected server response");
+      }
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error ?? "Failed to generate briefs");
+      }
+
+      setBriefs(data.briefs as Brief[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+      // Remove skeleton placeholders on error
+      setBriefs((prev) => prev.filter((b) => !b.id.startsWith("pending-")));
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  const readyBriefs = briefs.filter((b) => b.status === "ready");
+  const generatingBriefs = briefs.filter((b) => b.status === "generating");
+  const errorBriefs = briefs.filter((b) => b.status === "error");
+  const hasErrors = errorBriefs.length > 0;
+  const allDone = briefs.length > 0 && generatingBriefs.length === 0;
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900">
+            Jurisdiction Intelligence Briefs
+          </h2>
+          <p className="text-xs text-gray-500 mt-0.5">
+            AI-generated legal landscape, cultural context, and regulatory notes per jurisdiction
+          </p>
+        </div>
+
+        {allDone && (
+          <button
+            type="button"
+            onClick={() => void handleGenerate()}
+            disabled={isGenerating}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-500 border border-brand-grey rounded-lg hover:border-brand-purple hover:text-brand-purple disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            Regenerate
+          </button>
+        )}
+      </div>
+
+      {/* Server / network error */}
+      {error && (
+        <div className="flex items-start gap-2 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">
+          <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* Empty state (before auto-trigger fires) */}
+      {briefs.length === 0 && !isGenerating && (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <Sparkles className="w-8 h-8 text-brand-purple/40 mb-3" />
+          <p className="text-sm font-medium text-gray-500">Preparing briefs…</p>
+          <p className="text-xs text-gray-400 mt-1">
+            Intelligence briefs will generate automatically
+          </p>
+        </div>
+      )}
+
+      {/* Error retries banner */}
+      {hasErrors && allDone && (
+        <div className="flex items-center justify-between px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <p className="text-sm text-amber-700">
+            {errorBriefs.length} brief{errorBriefs.length !== 1 ? "s" : ""} failed to generate.
+          </p>
+          <button
+            type="button"
+            onClick={() => void handleGenerate()}
+            className="text-sm font-medium text-amber-700 hover:underline"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Generating skeletons */}
+      {generatingBriefs.map((b) => (
+        <BriefSkeleton key={b.id} jurisdictionName={b.jurisdiction_name} />
+      ))}
+
+      {/* Ready briefs */}
+      {readyBriefs.map((b) => (
+        <BriefCard key={b.id} brief={b} />
+      ))}
+    </div>
+  );
+}

--- a/app/matters/[id]/context/page.tsx
+++ b/app/matters/[id]/context/page.tsx
@@ -15,13 +15,17 @@ export default async function ContextPage({
 
   // Fetch full brief content (getMatterDetail only returns brief status)
   const service = createServiceClient();
-  const { data: briefs } = await service
+  const { data: briefs, error: briefsError } = await service
     .from("context_briefs")
     .select(
       "id, jurisdiction_code, jurisdiction_name, status, legal_landscape, cultural_intelligence, regulatory_notes"
     )
     .eq("matter_id", params.id)
     .order("jurisdiction_code");
+
+  if (briefsError) {
+    throw new Error(`Failed to load briefs: ${briefsError.message}`);
+  }
 
   return (
     <ContextTab

--- a/app/matters/[id]/context/page.tsx
+++ b/app/matters/[id]/context/page.tsx
@@ -1,10 +1,36 @@
-export default function ContextPage() {
+import { notFound } from "next/navigation";
+import { createServiceClient } from "@/lib/supabase/server";
+import { getMatterDetail } from "../_lib/getMatter";
+import ContextTab from "./_components/ContextTab";
+import type { Brief } from "./_components/BriefCard";
+
+export default async function ContextPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  // getMatterDetail is React-cached — deduplicates with the layout's call
+  const matter = await getMatterDetail(params.id);
+  if (!matter) notFound();
+
+  // Fetch full brief content (getMatterDetail only returns brief status)
+  const service = createServiceClient();
+  const { data: briefs } = await service
+    .from("context_briefs")
+    .select(
+      "id, jurisdiction_code, jurisdiction_name, status, legal_landscape, cultural_intelligence, regulatory_notes"
+    )
+    .eq("matter_id", params.id)
+    .order("jurisdiction_code");
+
   return (
-    <div className="flex flex-col items-center justify-center py-24 text-center">
-      <p className="text-sm font-medium text-gray-500">Context briefs</p>
-      <p className="text-xs text-gray-400 mt-1">
-        AI-generated jurisdiction intelligence — coming in Phase 1
-      </p>
-    </div>
+    <ContextTab
+      matterId={params.id}
+      initialBriefs={(briefs ?? []) as Brief[]}
+      jurisdictions={matter.matter_jurisdictions.map((j) => ({
+        jurisdiction_code: j.jurisdiction_code,
+        jurisdiction_name: j.jurisdiction_name,
+      }))}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the placeholder Context tab with a full interactive experience
- `BriefSkeleton` — pulsing loading card shown while Groq generates, with jurisdiction name and "Generating…" spinner
- `BriefCard` — displays a ready brief with three collapsible sections (Legal Landscape open by default; Cultural Intelligence and Regulatory Notes collapsed). Each section has a distinct left-border colour
- `ContextTab` (client component):
  - **Auto-triggers** `POST /api/context/generate` on first visit if no briefs exist
  - **Optimistic skeletons** appear immediately before the API responds
  - **Polls** `GET /api/context/[briefId]` every 2.5 s for any "generating" briefs (handles page-refresh-mid-generation)
  - **Error banner** with "Retry" button if any briefs errored
  - **"Regenerate" button** once all briefs are settled
- `context/page.tsx` (server) — fetches full brief content (layout's `getMatterDetail` only returns status) and passes it as initial state

## Demo flow
1. Create a new matter with 2–3 jurisdictions → redirected to Context tab
2. Skeletons appear immediately → Groq generates in parallel (~5–8 s)
3. All cards fade in with jurisdiction flag, name, and collapsible brief sections
4. Click a section header to expand/collapse

## Test plan
- [ ] Set `GROQ_API_KEY`, create matter → Context tab auto-generates and cards appear
- [ ] Navigate away and back — briefs are shown immediately from DB (no re-generation)
- [ ] Manually set a brief to `status: "error"` in DB → amber retry banner shown
- [ ] Refresh page while brief is `status: "generating"` → polling picks it up
- [ ] "Regenerate" button re-runs only non-ready briefs
- [ ] Each BriefCard section expands and collapses correctly
- [ ] No `GROQ_API_KEY` → error message shown in UI (not a crash)

Closes #17