### PR TITLE
Lawyer embedding regeneration and Flow tab placeholder fix

### DIFF
--- a/app/api/lawyers/[id]/embed/route.ts
+++ b/app/api/lawyers/[id]/embed/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { embedText, buildLawyerProfileText } from "@/lib/ai/embeddings";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const service = createServiceClient();
+
+  // Fetch the lawyer — ownership verified by email
+  const { data: lawyer, error: lawyerError } = await service
+    .from("lawyers")
+    .select("id, email, full_name, title, office_city, languages, bio")
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (lawyerError || !lawyer) {
+    return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
+  }
+
+  // Only the lawyer themselves can regenerate their own embedding
+  if (lawyer.email !== user.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Fetch jurisdictions for profile text
+  const { data: jurisdictions, error: jurError } = await service
+    .from("lawyer_jurisdictions")
+    .select("jurisdiction_code, jurisdiction_name, matter_types")
+    .eq("lawyer_id", params.id);
+
+  if (jurError) {
+    return NextResponse.json({ error: "Failed to load jurisdictions" }, { status: 500 });
+  }
+
+  const profileText = buildLawyerProfileText({
+    full_name: lawyer.full_name,
+    title: lawyer.title,
+    office_city: lawyer.office_city,
+    languages: lawyer.languages,
+    bio: lawyer.bio,
+    lawyer_jurisdictions: (jurisdictions ?? []) as {
+      jurisdiction_code: string;
+      jurisdiction_name: string;
+      matter_types: string[];
+    }[],
+  });
+
+  const embedding = await embedText(profileText);
+
+  const { error: updateError } = await service
+    .from("lawyers")
+    .update({ embedding: JSON.stringify(embedding) })
+    .eq("id", params.id);
+
+  if (updateError) {
+    return NextResponse.json({ error: "Failed to save embedding" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    dimensions: embedding.length,
+    generated_at: new Date().toISOString(),
+  });
+}

--- a/app/api/lawyers/[id]/embed/route.ts
+++ b/app/api/lawyers/[id]/embed/route.ts
@@ -24,7 +24,17 @@ export async function POST(
     .eq("id", params.id)
     .maybeSingle();
 
-  if (lawyerError || !lawyer) {
+  if (lawyerError) {
+    const isInvalidUuid =
+      lawyerError.code === "22P02" ||
+      lawyerError.message?.toLowerCase().includes("invalid input syntax for type uuid");
+    return NextResponse.json(
+      { error: isInvalidUuid ? "Invalid lawyer id" : "Failed to load lawyer" },
+      { status: isInvalidUuid ? 400 : 500 }
+    );
+  }
+
+  if (!lawyer) {
     return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
   }
 
@@ -57,6 +67,13 @@ export async function POST(
   });
 
   const embedding = await embedText(profileText);
+
+  if (embedding.length !== 384 || !embedding.every(Number.isFinite)) {
+    return NextResponse.json(
+      { error: "Embedding generation produced an invalid vector" },
+      { status: 500 }
+    );
+  }
 
   const { error: updateError } = await service
     .from("lawyers")

--- a/app/api/lawyers/[id]/route.ts
+++ b/app/api/lawyers/[id]/route.ts
@@ -164,8 +164,8 @@ export async function PATCH(
   void fetch(new URL(`/api/lawyers/${params.id}/embed`, req.url).toString(), {
     method: "POST",
     headers: { cookie: req.headers.get("cookie") ?? "" },
-  }).catch(() => {
-    // Best-effort — failure is non-critical; embed-lawyers script can re-sync
+  }).catch((err) => {
+    console.error("Failed to regenerate lawyer embedding", { lawyerId: params.id, err });
   });
 
   return NextResponse.json({ success: true });

--- a/app/api/lawyers/[id]/route.ts
+++ b/app/api/lawyers/[id]/route.ts
@@ -160,7 +160,13 @@ export async function PATCH(
     }
   }
 
-  // TODO: Trigger embedding regeneration (issue #25)
+  // Regenerate embedding non-blocking — don't make the profile save wait for it
+  void fetch(new URL(`/api/lawyers/${params.id}/embed`, req.url).toString(), {
+    method: "POST",
+    headers: { cookie: req.headers.get("cookie") ?? "" },
+  }).catch(() => {
+    // Best-effort — failure is non-critical; embed-lawyers script can re-sync
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/app/matters/[id]/flow/page.tsx
+++ b/app/matters/[id]/flow/page.tsx
@@ -3,7 +3,7 @@ export default function FlowPage() {
     <div className="flex flex-col items-center justify-center py-24 text-center">
       <p className="text-sm font-medium text-gray-500">Task flow</p>
       <p className="text-xs text-gray-400 mt-1">
-        Cross-timezone task routing and handoffs — coming in Phase 2
+        Cross-timezone task routing and handoffs — coming soon
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- `app/api/lawyers/[id]/embed/route.ts`: POST endpoint — owner-only (403 for others), fetches full profile + jurisdictions, regenerates 384-dim embedding, stores in Supabase
- `app/api/lawyers/[id]/route.ts`: PATCH now fires embedding regeneration non-blocking after a successful profile update (removes the TODO left in Phase 1)
- `app/matters/[id]/flow/page.tsx`: fixes stale "coming in Phase 2" placeholder text

## Test plan
- [x] `POST /api/lawyers/[id]/embed` returns `{ success: true, dimensions: 384, generated_at: ... }`
- [x] Non-owner receives 403
- [x] Profile PATCH triggers re-embed non-blocking
- [x] `npx tsc --noEmit` clean

Closes #25