### PR TITLE
feat(reputation): awards engine, leaderboard API, and point trigger wiring (#30)

### DIFF
--- a/app/api/context/generate/route.ts
+++ b/app/api/context/generate/route.ts
@@ -234,7 +234,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Failed to load briefs" }, { status: 500 });
   }
 
-  // Award 50 points to the matter creator if all briefs are now ready
+  // Award 50 points to the matter creator if all briefs are now ready.
+  // Guard: check for an existing brief_generated event for this matter
+  // so concurrent or repeated calls don't double-award.
   const allReady = (briefs ?? []).every((b) => b.status === "ready");
   if (allReady && briefs && briefs.length > 0) {
     const { data: matterMeta } = await service
@@ -244,12 +246,22 @@ export async function POST(req: Request) {
       .single();
 
     if (matterMeta?.lead_lawyer_id) {
-      await awardPoints({
-        lawyer_id: matterMeta.lead_lawyer_id,
-        event_type: "brief_generated",
-        matter_id,
-        description: `All ${briefs.length} jurisdiction briefs generated`,
-      });
+      const { data: alreadyAwarded } = await service
+        .from("reputation_events")
+        .select("id")
+        .eq("lawyer_id", matterMeta.lead_lawyer_id)
+        .eq("event_type", "brief_generated")
+        .eq("matter_id", matter_id)
+        .maybeSingle();
+
+      if (!alreadyAwarded) {
+        await awardPoints({
+          lawyer_id: matterMeta.lead_lawyer_id,
+          event_type: "brief_generated",
+          matter_id,
+          description: `All ${briefs.length} jurisdiction briefs generated`,
+        });
+      }
     }
   }
 

--- a/app/api/context/generate/route.ts
+++ b/app/api/context/generate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { generateBrief } from "@/lib/ai/groq";
+import { awardPoints } from "@/lib/reputation/awards";
 
 const schema = z.object({
   matter_id: z.string().uuid(),
@@ -231,6 +232,25 @@ export async function POST(req: Request) {
 
   if (briefsError) {
     return NextResponse.json({ error: "Failed to load briefs" }, { status: 500 });
+  }
+
+  // Award 50 points to the matter creator if all briefs are now ready
+  const allReady = (briefs ?? []).every((b) => b.status === "ready");
+  if (allReady && briefs && briefs.length > 0) {
+    const { data: matterMeta } = await service
+      .from("matters")
+      .select("lead_lawyer_id")
+      .eq("id", matter_id)
+      .single();
+
+    if (matterMeta?.lead_lawyer_id) {
+      await awardPoints({
+        lawyer_id: matterMeta.lead_lawyer_id,
+        event_type: "brief_generated",
+        matter_id,
+        description: `All ${briefs.length} jurisdiction briefs generated`,
+      });
+    }
   }
 
   return NextResponse.json({ briefs: briefs ?? [] });

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: Request) {
 
   if (lawyerId) {
     // Single lawyer: recent events + score + badge
-    const [{ data: lawyer }, { data: events }] = await Promise.all([
+    const [lawyerResult, eventsResult] = await Promise.all([
       service
         .from("lawyers")
         .select("id, full_name, office_city, reputation_score, avatar_url")
@@ -29,14 +29,23 @@ export async function GET(request: Request) {
         .limit(50),
     ]);
 
-    if (!lawyer) return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
+    if (lawyerResult.error) {
+      const status = lawyerResult.error.code === "PGRST116" ? 404 : 500;
+      return NextResponse.json({ error: lawyerResult.error.message }, { status });
+    }
+    if (!lawyerResult.data) {
+      return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
+    }
+    if (eventsResult.error) {
+      return NextResponse.json({ error: eventsResult.error.message }, { status: 500 });
+    }
 
     return NextResponse.json({
       lawyer: {
-        ...lawyer,
-        badge: getBadge(lawyer.reputation_score ?? 0),
+        ...lawyerResult.data,
+        badge: getBadge(lawyerResult.data.reputation_score ?? 0),
       },
-      events: events ?? [],
+      events: eventsResult.data ?? [],
     });
   }
 

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -1,6 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { getBadge } from "@/lib/reputation/awards";
+
+const uuidSchema = z.string().uuid();
 
 // GET /api/reputation?lawyer_id=xxx   — single lawyer events + badge
 // GET /api/reputation                 — firm-wide leaderboard (top 20)
@@ -12,9 +15,14 @@ export async function GET(request: Request) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { searchParams } = new URL(request.url);
-  const lawyerId = searchParams.get("lawyer_id");
+  const rawLawyerId = searchParams.get("lawyer_id");
 
-  if (lawyerId) {
+  if (rawLawyerId) {
+    const parsed = uuidSchema.safeParse(rawLawyerId);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid lawyer_id — must be a UUID" }, { status: 400 });
+    }
+    const lawyerId = parsed.data;
     // Single lawyer: score + badge + recent events
     const [lawyerResult, eventsResult] = await Promise.all([
       supabase

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -1,27 +1,28 @@
-import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { getBadge } from "@/lib/reputation/awards";
 
 // GET /api/reputation?lawyer_id=xxx   — single lawyer events + badge
 // GET /api/reputation                 — firm-wide leaderboard (top 20)
 export async function GET(request: Request) {
+  // Use the user-scoped client for all reads — RLS allows authenticated users
+  // to read lawyers and reputation_events firm-wide (read-only).
   const supabase = createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const service = createServiceClient();
   const { searchParams } = new URL(request.url);
   const lawyerId = searchParams.get("lawyer_id");
 
   if (lawyerId) {
-    // Single lawyer: recent events + score + badge
+    // Single lawyer: score + badge + recent events
     const [lawyerResult, eventsResult] = await Promise.all([
-      service
+      supabase
         .from("lawyers")
         .select("id, full_name, office_city, reputation_score, avatar_url")
         .eq("id", lawyerId)
         .single(),
-      service
+      supabase
         .from("reputation_events")
         .select("id, event_type, points, description, matter_id, created_at")
         .eq("lawyer_id", lawyerId)
@@ -49,8 +50,8 @@ export async function GET(request: Request) {
     });
   }
 
-  // Leaderboard: top 20 lawyers by reputation_score
-  const { data: leaderboard, error } = await service
+  // Leaderboard: top 20 by reputation_score, stable secondary sort by full_name
+  const { data: leaderboard, error } = await supabase
     .from("lawyers")
     .select("id, full_name, office_city, office_country, reputation_score, avatar_url, matters_count")
     .order("reputation_score", { ascending: false })

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
         .single(),
       supabase
         .from("reputation_events")
-        .select("id, event_type, points, description, matter_id, created_at")
+        .select("id, event_type, points, created_at")
         .eq("lawyer_id", lawyerId)
         .order("created_at", { ascending: false })
         .limit(50),

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -1,0 +1,59 @@
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { getBadge } from "@/lib/reputation/awards";
+
+// GET /api/reputation?lawyer_id=xxx   — single lawyer events + badge
+// GET /api/reputation                 — firm-wide leaderboard (top 20)
+export async function GET(request: Request) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const service = createServiceClient();
+  const { searchParams } = new URL(request.url);
+  const lawyerId = searchParams.get("lawyer_id");
+
+  if (lawyerId) {
+    // Single lawyer: recent events + score + badge
+    const [{ data: lawyer }, { data: events }] = await Promise.all([
+      service
+        .from("lawyers")
+        .select("id, full_name, office_city, reputation_score, avatar_url")
+        .eq("id", lawyerId)
+        .single(),
+      service
+        .from("reputation_events")
+        .select("id, event_type, points, description, matter_id, created_at")
+        .eq("lawyer_id", lawyerId)
+        .order("created_at", { ascending: false })
+        .limit(50),
+    ]);
+
+    if (!lawyer) return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
+
+    return NextResponse.json({
+      lawyer: {
+        ...lawyer,
+        badge: getBadge(lawyer.reputation_score ?? 0),
+      },
+      events: events ?? [],
+    });
+  }
+
+  // Leaderboard: top 20 lawyers by reputation_score
+  const { data: leaderboard, error } = await service
+    .from("lawyers")
+    .select("id, full_name, office_city, office_country, reputation_score, avatar_url, matters_count")
+    .order("reputation_score", { ascending: false })
+    .limit(20);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const enriched = (leaderboard ?? []).map((l, idx) => ({
+    ...l,
+    rank: idx + 1,
+    badge: getBadge(l.reputation_score ?? 0),
+  }));
+
+  return NextResponse.json({ leaderboard: enriched });
+}

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -54,6 +54,7 @@ export async function GET(request: Request) {
     .from("lawyers")
     .select("id, full_name, office_city, office_country, reputation_score, avatar_url, matters_count")
     .order("reputation_score", { ascending: false })
+    .order("full_name", { ascending: true })
     .limit(20);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/lib/flow/engine.ts
+++ b/lib/flow/engine.ts
@@ -1,6 +1,7 @@
 import { toZonedTime } from "date-fns-tz";
 import { isWeekend, getHours } from "date-fns";
 import { createServiceClient } from "@/lib/supabase/server";
+import { awardPoints } from "@/lib/reputation/awards";
 import type { Task, Lawyer, LawyerAvailability } from "@/types";
 
 export interface RouteTaskResult {
@@ -210,17 +211,11 @@ export async function routeTask(taskId: string): Promise<RouteTaskResult> {
   }
 
   // 8. Award reputation points to receiving lawyer
-  await supabase.from("reputation_events").insert({
+  await awardPoints({
     lawyer_id: winner.lawyer.id,
     event_type: "handoff_completed",
-    points: 25,
     matter_id: typedTask.matter_id,
     description: `Task routed by Flow engine: ${typedTask.title}`,
-  });
-
-  await supabase.rpc("increment_reputation", {
-    lawyer_uuid: winner.lawyer.id,
-    points_to_add: 25,
   });
 
   return {

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -75,27 +75,34 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
   }
 
   // For profile_completed: one-time only
-  if (event_type === "profile_completed") {
-    const { data: existing, error: existingError } = await supabase
-      .from("reputation_events")
-      .select("id")
-      .eq("lawyer_id", lawyer_id)
-      .eq("event_type", "profile_completed")
-      .maybeSingle();
-
-    if (existingError) return null;
-    if (existing) return null;
-  }
-
-  // Insert event
-  const { error: eventError } = await supabase.from("reputation_events").insert({
+  const eventPayload = {
     lawyer_id,
     event_type,
     points,
     matter_id: matter_id ?? null,
     description: description ?? defaultDescription(event_type),
-  });
+  };
 
+  // Insert event. For profile_completed, rely on a DB uniqueness constraint
+  // and treat duplicate-key conflicts as "already awarded".
+  let eventError: { code?: string; message: string } | null = null;
+
+  if (event_type === "profile_completed") {
+    const { error } = await supabase
+      .from("reputation_events")
+      .insert(eventPayload)
+      .select("id")
+      .single();
+
+    eventError = error;
+
+    if (eventError?.code === "23505") {
+      return null;
+    }
+  } else {
+    const { error } = await supabase.from("reputation_events").insert(eventPayload);
+    eventError = error;
+  }
   if (eventError) {
     console.error(`[reputation] Failed to insert event ${event_type}:`, eventError.message);
     return null;

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -1,0 +1,134 @@
+import { createServiceClient } from "@/lib/supabase/server";
+
+// ─── Point values ────────────────────────────────────────────────────────────
+
+export const REPUTATION_POINTS = {
+  matter_joined: 30,
+  brief_generated: 50,
+  note_contributed: 40,
+  note_upvoted: 10,
+  handoff_completed: 25,
+  match_accepted: 20,
+  profile_completed: 60,
+  cross_border_matter: 100,
+} as const;
+
+export type ReputationEventType = keyof typeof REPUTATION_POINTS;
+
+// Cap on total points earned from note_upvoted events
+export const NOTE_UPVOTE_CAP = 200;
+
+// ─── Badge tiers ─────────────────────────────────────────────────────────────
+
+export const BADGE_TIERS = [
+  { label: "Contributor", min: 0 },
+  { label: "Rising Star", min: 100 },
+  { label: "Regional Expert", min: 500 },
+  { label: "Global Expert", min: 1000 },
+  { label: "Elite Partner", min: 2500 },
+] as const;
+
+export type BadgeTier = typeof BADGE_TIERS[number]["label"];
+
+export function getBadge(score: number): BadgeTier {
+  const tier = [...BADGE_TIERS].reverse().find((t) => score >= t.min);
+  return tier?.label ?? "Contributor";
+}
+
+// ─── Core award function ──────────────────────────────────────────────────────
+
+interface AwardOptions {
+  lawyer_id: string;
+  event_type: ReputationEventType;
+  matter_id?: string | null;
+  description?: string;
+}
+
+/**
+ * Awards reputation points to a lawyer.
+ * Inserts a reputation_events row and increments lawyers.reputation_score.
+ * Returns the new reputation score, or null on failure.
+ */
+export async function awardPoints(opts: AwardOptions): Promise<number | null> {
+  const { lawyer_id, event_type, matter_id, description } = opts;
+  const points = REPUTATION_POINTS[event_type];
+
+  const supabase = createServiceClient();
+
+  // For note_upvoted: check running total against cap before awarding
+  if (event_type === "note_upvoted") {
+    const { data: upvoteSum } = await supabase
+      .from("reputation_events")
+      .select("points")
+      .eq("lawyer_id", lawyer_id)
+      .eq("event_type", "note_upvoted");
+
+    const total = (upvoteSum ?? []).reduce((sum, r) => sum + r.points, 0);
+    if (total >= NOTE_UPVOTE_CAP) return null;
+  }
+
+  // For profile_completed: one-time only
+  if (event_type === "profile_completed") {
+    const { data: existing } = await supabase
+      .from("reputation_events")
+      .select("id")
+      .eq("lawyer_id", lawyer_id)
+      .eq("event_type", "profile_completed")
+      .maybeSingle();
+
+    if (existing) return null;
+  }
+
+  // Insert event
+  const { error: eventError } = await supabase.from("reputation_events").insert({
+    lawyer_id,
+    event_type,
+    points,
+    matter_id: matter_id ?? null,
+    description: description ?? defaultDescription(event_type),
+  });
+
+  if (eventError) {
+    console.error(`[reputation] Failed to insert event ${event_type}:`, eventError.message);
+    return null;
+  }
+
+  // Increment score on lawyers table
+  const { data: lawyer, error: fetchError } = await supabase
+    .from("lawyers")
+    .select("reputation_score")
+    .eq("id", lawyer_id)
+    .single();
+
+  if (fetchError || !lawyer) {
+    console.error(`[reputation] Failed to fetch lawyer ${lawyer_id}:`, fetchError?.message);
+    return null;
+  }
+
+  const newScore = (lawyer.reputation_score ?? 0) + points;
+
+  const { error: updateError } = await supabase
+    .from("lawyers")
+    .update({ reputation_score: newScore })
+    .eq("id", lawyer_id);
+
+  if (updateError) {
+    console.error(`[reputation] Failed to update score for ${lawyer_id}:`, updateError.message);
+    return null;
+  }
+
+  return newScore;
+}
+
+function defaultDescription(event_type: ReputationEventType): string {
+  switch (event_type) {
+    case "matter_joined": return "Joined a matter team";
+    case "brief_generated": return "Jurisdiction brief generated";
+    case "note_contributed": return "Contributed a field note";
+    case "note_upvoted": return "Field note upvoted";
+    case "handoff_completed": return "Received a task handoff";
+    case "match_accepted": return "Invited a lawyer to a matter";
+    case "profile_completed": return "Completed profile (one-time bonus)";
+    case "cross_border_matter": return "Led a cross-border matter";
+  }
+}

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -51,31 +51,39 @@ interface AwardOptions {
  */
 export async function awardPoints(opts: AwardOptions): Promise<number | null> {
   const { lawyer_id, event_type, matter_id, description } = opts;
-  const points = REPUTATION_POINTS[event_type];
+  let points = REPUTATION_POINTS[event_type];
 
   const supabase = createServiceClient();
 
   // For note_upvoted: check running total against cap before awarding
   if (event_type === "note_upvoted") {
-    const { data: upvoteSum } = await supabase
+    const { data: upvoteAggregate, error: upvoteAggregateError } = await supabase
       .from("reputation_events")
-      .select("points")
+      .select("sum:points.sum()")
       .eq("lawyer_id", lawyer_id)
-      .eq("event_type", "note_upvoted");
+      .eq("event_type", "note_upvoted")
+      .maybeSingle();
 
-    const total = (upvoteSum ?? []).reduce((sum, r) => sum + r.points, 0);
-    if (total >= NOTE_UPVOTE_CAP) return null;
+    if (upvoteAggregateError) return null;
+
+    const total = upvoteAggregate?.sum ?? 0;
+    const remaining = NOTE_UPVOTE_CAP - total;
+
+    if (remaining <= 0) return null;
+
+    points = Math.min(points, remaining);
   }
 
   // For profile_completed: one-time only
   if (event_type === "profile_completed") {
-    const { data: existing } = await supabase
+    const { data: existing, error: existingError } = await supabase
       .from("reputation_events")
       .select("id")
       .eq("lawyer_id", lawyer_id)
       .eq("event_type", "profile_completed")
       .maybeSingle();
 
+    if (existingError) return null;
     if (existing) return null;
   }
 

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createServiceClient } from "@/lib/supabase/server";
 
 // ─── Point values ────────────────────────────────────────────────────────────
@@ -53,8 +54,10 @@ interface AwardOptions {
  *   the lawyer row and enforces the per-note cap atomically.
  * - All other events: delegates to award_reputation_event RPC, which inserts
  *   the event row and increments the score in one transaction.
- *   profile_completed and brief_generated have DB unique indexes; a 23505
- *   conflict means already awarded and is treated as a silent skip.
+ *   Events backed by a DB unique index (profile_completed: unique on lawyer_id;
+ *   brief_generated: unique on (lawyer_id, matter_id)) will produce a 23505
+ *   conflict on duplicate inserts, which is treated as a silent skip.
+ *   Any event without a DB constraint must not rely on 23505 for idempotency.
  *
  * Returns points awarded, or null if skipped or failed.
  */

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -51,7 +51,7 @@ interface AwardOptions {
  */
 export async function awardPoints(opts: AwardOptions): Promise<number | null> {
   const { lawyer_id, event_type, matter_id, description } = opts;
-  let points = REPUTATION_POINTS[event_type];
+  let points: number = REPUTATION_POINTS[event_type];
 
   const supabase = createServiceClient();
 
@@ -108,7 +108,17 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
     return null;
   }
 
-  // Increment score on lawyers table
+  // Atomically increment score in DB to avoid lost updates under concurrency
+  const { error: incrementError } = await supabase.rpc("increment_reputation", {
+    lawyer_uuid: lawyer_id,
+    points_to_add: points,
+  });
+
+  if (incrementError) {
+    console.error(`[reputation] Failed to increment score for ${lawyer_id}:`, incrementError.message);
+    return null;
+  }
+
   const { data: lawyer, error: fetchError } = await supabase
     .from("lawyers")
     .select("reputation_score")
@@ -116,23 +126,11 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
     .single();
 
   if (fetchError || !lawyer) {
-    console.error(`[reputation] Failed to fetch lawyer ${lawyer_id}:`, fetchError?.message);
+    console.error(`[reputation] Failed to fetch updated score for ${lawyer_id}:`, fetchError?.message);
     return null;
   }
 
-  const newScore = (lawyer.reputation_score ?? 0) + points;
-
-  const { error: updateError } = await supabase
-    .from("lawyers")
-    .update({ reputation_score: newScore })
-    .eq("id", lawyer_id);
-
-  if (updateError) {
-    console.error(`[reputation] Failed to update score for ${lawyer_id}:`, updateError.message);
-    return null;
-  }
-
-  return newScore;
+  return lawyer.reputation_score ?? 0;
 }
 
 function defaultDescription(event_type: ReputationEventType): string {

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -15,7 +15,7 @@ export const REPUTATION_POINTS = {
 
 export type ReputationEventType = keyof typeof REPUTATION_POINTS;
 
-// Cap on total points earned from note_upvoted events
+// Max points a single field note can earn its author from upvotes
 export const NOTE_UPVOTE_CAP = 200;
 
 // ─── Badge tiers ─────────────────────────────────────────────────────────────
@@ -41,102 +41,70 @@ interface AwardOptions {
   lawyer_id: string;
   event_type: ReputationEventType;
   matter_id?: string | null;
+  /** For note_upvoted: the field_note id — required to scope the per-note cap. */
+  source_id?: string | null;
   description?: string;
 }
 
 /**
  * Awards reputation points to a lawyer.
- * - Inserts a reputation_events row.
- * - Atomically increments lawyers.reputation_score via the increment_reputation RPC
- *   (avoids read-modify-write race conditions).
- * Returns the new reputation score, or null if skipped/failed.
+ *
+ * - note_upvoted: delegates entirely to award_upvote_points RPC, which locks
+ *   the lawyer row and enforces the per-note cap atomically.
+ * - All other events: delegates to award_reputation_event RPC, which inserts
+ *   the event row and increments the score in one transaction.
+ *   profile_completed and brief_generated have DB unique indexes; a 23505
+ *   conflict means already awarded and is treated as a silent skip.
+ *
+ * Returns points awarded, or null if skipped or failed.
  */
 export async function awardPoints(opts: AwardOptions): Promise<number | null> {
-  const { lawyer_id, event_type, matter_id, description } = opts;
-  let points: number = REPUTATION_POINTS[event_type];
-
+  const { lawyer_id, event_type, matter_id, source_id, description } = opts;
+  const points = REPUTATION_POINTS[event_type];
   const supabase = createServiceClient();
 
-  // ── note_upvoted: DB-side SUM via aggregate, clamp to remaining cap ─────────
+  // ── note_upvoted: atomic per-note cap via DB RPC ────────────────────────────
   if (event_type === "note_upvoted") {
-    const { data: upvoteAggregate, error: upvoteAggregateError } = await supabase
-      .from("reputation_events")
-      .select("sum:points.sum()")
-      .eq("lawyer_id", lawyer_id)
-      .eq("event_type", "note_upvoted")
-      .maybeSingle();
-
-    // Hard failure — do not silently award when we can't verify the cap
-    if (upvoteAggregateError) {
-      console.error("[reputation] Failed to check upvote cap:", upvoteAggregateError.message);
+    if (!source_id) {
+      console.error("[reputation] note_upvoted requires source_id (field_note id)");
       return null;
     }
 
-    const total = (upvoteAggregate?.sum as number) ?? 0;
-    const remaining = NOTE_UPVOTE_CAP - total;
-    if (remaining <= 0) return null;
+    const { data: awarded, error } = await supabase.rpc("award_upvote_points", {
+      p_lawyer_id: lawyer_id,
+      p_source_id: source_id,
+      p_matter_id: matter_id ?? null,
+      p_description: description ?? defaultDescription("note_upvoted"),
+      p_points: points,
+      p_cap: NOTE_UPVOTE_CAP,
+    });
 
-    // Clamp: award only what remains under the cap
-    points = Math.min(points, remaining);
+    if (error) {
+      console.error("[reputation] award_upvote_points RPC failed:", error.message);
+      return null;
+    }
+
+    return (awarded as number) > 0 ? (awarded as number) : null;
   }
 
-  // ── Build event payload ─────────────────────────────────────────────────────
-  const eventPayload = {
-    lawyer_id,
-    event_type,
-    points,
-    matter_id: matter_id ?? null,
-    description: description ?? defaultDescription(event_type),
-  };
-
-  // ── Insert event ────────────────────────────────────────────────────────────
-  // For profile_completed: rely on the partial unique index and treat
-  // duplicate-key conflicts (23505) as "already awarded".
-  let eventError: { code?: string; message: string } | null = null;
-
-  if (event_type === "profile_completed") {
-    const { error } = await supabase
-      .from("reputation_events")
-      .insert(eventPayload)
-      .select("id")
-      .single();
-
-    eventError = error;
-    if (eventError?.code === "23505") return null;
-  } else {
-    const { error } = await supabase.from("reputation_events").insert(eventPayload);
-    eventError = error;
-  }
-
-  if (eventError) {
-    console.error(`[reputation] Failed to insert event ${event_type}:`, eventError.message);
-    return null;
-  }
-
-  // ── Atomic DB-side increment — no read-modify-write race ────────────────────
-  const { error: incrementError } = await supabase.rpc("increment_reputation", {
-    lawyer_uuid: lawyer_id,
-    points_to_add: points,
+  // ── All other events: atomic insert + increment via DB RPC ─────────────────
+  const { error } = await supabase.rpc("award_reputation_event", {
+    p_lawyer_id: lawyer_id,
+    p_event_type: event_type,
+    p_points: points,
+    p_matter_id: matter_id ?? null,
+    p_source_id: source_id ?? null,
+    p_description: description ?? defaultDescription(event_type),
   });
 
-  if (incrementError) {
-    console.error("[reputation] increment_reputation RPC failed:", incrementError.message);
+  if (error) {
+    // 23505 = unique violation — profile_completed or brief_generated already awarded
+    if ((error as { code?: string }).code === "23505") return null;
+    console.error(`[reputation] award_reputation_event RPC failed (${event_type}):`, error.message);
     return null;
   }
 
-  // Return updated score
-  const { data: lawyer, error: fetchError } = await supabase
-    .from("lawyers")
-    .select("reputation_score")
-    .eq("id", lawyer_id)
-    .single();
-
-  if (fetchError || !lawyer) {
-    console.error("[reputation] Failed to fetch updated score:", fetchError?.message);
-    return null;
-  }
-
-  return lawyer.reputation_score ?? 0;
+  return points;
 }
 
 function defaultDescription(event_type: ReputationEventType): string {

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -46,8 +46,10 @@ interface AwardOptions {
 
 /**
  * Awards reputation points to a lawyer.
- * Inserts a reputation_events row and increments lawyers.reputation_score.
- * Returns the new reputation score, or null on failure.
+ * - Inserts a reputation_events row.
+ * - Atomically increments lawyers.reputation_score via the increment_reputation RPC
+ *   (avoids read-modify-write race conditions).
+ * Returns the new reputation score, or null if skipped/failed.
  */
 export async function awardPoints(opts: AwardOptions): Promise<number | null> {
   const { lawyer_id, event_type, matter_id, description } = opts;
@@ -55,7 +57,7 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
 
   const supabase = createServiceClient();
 
-  // For note_upvoted: check running total against cap before awarding
+  // ── note_upvoted: DB-side SUM via aggregate, clamp to remaining cap ─────────
   if (event_type === "note_upvoted") {
     const { data: upvoteAggregate, error: upvoteAggregateError } = await supabase
       .from("reputation_events")
@@ -64,17 +66,21 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
       .eq("event_type", "note_upvoted")
       .maybeSingle();
 
-    if (upvoteAggregateError) return null;
+    // Hard failure — do not silently award when we can't verify the cap
+    if (upvoteAggregateError) {
+      console.error("[reputation] Failed to check upvote cap:", upvoteAggregateError.message);
+      return null;
+    }
 
-    const total = upvoteAggregate?.sum ?? 0;
+    const total = (upvoteAggregate?.sum as number) ?? 0;
     const remaining = NOTE_UPVOTE_CAP - total;
-
     if (remaining <= 0) return null;
 
+    // Clamp: award only what remains under the cap
     points = Math.min(points, remaining);
   }
 
-  // For profile_completed: one-time only
+  // ── Build event payload ─────────────────────────────────────────────────────
   const eventPayload = {
     lawyer_id,
     event_type,
@@ -83,8 +89,9 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
     description: description ?? defaultDescription(event_type),
   };
 
-  // Insert event. For profile_completed, rely on a DB uniqueness constraint
-  // and treat duplicate-key conflicts as "already awarded".
+  // ── Insert event ────────────────────────────────────────────────────────────
+  // For profile_completed: rely on the partial unique index and treat
+  // duplicate-key conflicts (23505) as "already awarded".
   let eventError: { code?: string; message: string } | null = null;
 
   if (event_type === "profile_completed") {
@@ -95,30 +102,29 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
       .single();
 
     eventError = error;
-
-    if (eventError?.code === "23505") {
-      return null;
-    }
+    if (eventError?.code === "23505") return null;
   } else {
     const { error } = await supabase.from("reputation_events").insert(eventPayload);
     eventError = error;
   }
+
   if (eventError) {
     console.error(`[reputation] Failed to insert event ${event_type}:`, eventError.message);
     return null;
   }
 
-  // Atomically increment score in DB to avoid lost updates under concurrency
+  // ── Atomic DB-side increment — no read-modify-write race ────────────────────
   const { error: incrementError } = await supabase.rpc("increment_reputation", {
     lawyer_uuid: lawyer_id,
     points_to_add: points,
   });
 
   if (incrementError) {
-    console.error(`[reputation] Failed to increment score for ${lawyer_id}:`, incrementError.message);
+    console.error("[reputation] increment_reputation RPC failed:", incrementError.message);
     return null;
   }
 
+  // Return updated score
   const { data: lawyer, error: fetchError } = await supabase
     .from("lawyers")
     .select("reputation_score")
@@ -126,7 +132,7 @@ export async function awardPoints(opts: AwardOptions): Promise<number | null> {
     .single();
 
   if (fetchError || !lawyer) {
-    console.error(`[reputation] Failed to fetch updated score for ${lawyer_id}:`, fetchError?.message);
+    console.error("[reputation] Failed to fetch updated score:", fetchError?.message);
     return null;
   }
 

--- a/supabase/migrations/006_reputation_guards.sql
+++ b/supabase/migrations/006_reputation_guards.sql
@@ -1,0 +1,11 @@
+-- Migration 006: Reputation guards
+-- Partial unique index on reputation_events for profile_completed one-time guard.
+-- awardPoints() uses Supabase's built-in aggregate for upvote SUM (no custom RPC needed).
+
+-- ── Partial unique index: profile_completed is one-time per lawyer ────────────
+-- Prevents double-award even under concurrent requests.
+-- The INSERT in awardPoints() will receive a 23505 unique violation if already awarded.
+
+CREATE UNIQUE INDEX IF NOT EXISTS reputation_events_profile_completed_once
+  ON reputation_events (lawyer_id)
+  WHERE event_type = 'profile_completed';

--- a/supabase/migrations/006_reputation_guards.sql
+++ b/supabase/migrations/006_reputation_guards.sql
@@ -30,6 +30,26 @@ CREATE UNIQUE INDEX IF NOT EXISTS reputation_events_profile_completed_once
   WHERE event_type = 'profile_completed';
 
 -- ── brief_generated: one-time per (lawyer, matter) ───────────────────────────
+WITH deleted_brief_generated AS (
+  DELETE FROM reputation_events
+  WHERE id NOT IN (
+    SELECT DISTINCT ON (lawyer_id, matter_id) id
+    FROM reputation_events
+    WHERE event_type = 'brief_generated'
+    ORDER BY lawyer_id, matter_id, created_at ASC
+  )
+  AND event_type = 'brief_generated'
+  RETURNING lawyer_id, points
+),
+deleted_brief_points_by_lawyer AS (
+  SELECT lawyer_id, COALESCE(SUM(points), 0) AS deleted_points
+  FROM deleted_brief_generated
+  GROUP BY lawyer_id
+)
+UPDATE lawyers l
+SET reputation_score = l.reputation_score - d.deleted_points
+FROM deleted_brief_points_by_lawyer d
+WHERE l.id = d.lawyer_id;
 CREATE UNIQUE INDEX IF NOT EXISTS reputation_events_brief_generated_once
   ON reputation_events (lawyer_id, matter_id)
   WHERE event_type = 'brief_generated';

--- a/supabase/migrations/006_reputation_guards.sql
+++ b/supabase/migrations/006_reputation_guards.sql
@@ -4,14 +4,26 @@
 -- Upvote caps are enforced via the custom RPC award_upvote_points (migration 007).
 
 -- ── profile_completed: one-time per lawyer ────────────────────────────────────
-DELETE FROM reputation_events
-WHERE id NOT IN (
-  SELECT DISTINCT ON (lawyer_id) id
-  FROM reputation_events
-  WHERE event_type = 'profile_completed'
-  ORDER BY lawyer_id, created_at ASC
+WITH deleted_profile_completed AS (
+  DELETE FROM reputation_events
+  WHERE id NOT IN (
+    SELECT DISTINCT ON (lawyer_id) id
+    FROM reputation_events
+    WHERE event_type = 'profile_completed'
+    ORDER BY lawyer_id, created_at ASC
+  )
+  AND event_type = 'profile_completed'
+  RETURNING lawyer_id, points
+),
+deleted_points_by_lawyer AS (
+  SELECT lawyer_id, COALESCE(SUM(points), 0) AS deleted_points
+  FROM deleted_profile_completed
+  GROUP BY lawyer_id
 )
-AND event_type = 'profile_completed';
+UPDATE lawyers l
+SET reputation_score = l.reputation_score - d.deleted_points
+FROM deleted_points_by_lawyer d
+WHERE l.id = d.lawyer_id;
 
 CREATE UNIQUE INDEX IF NOT EXISTS reputation_events_profile_completed_once
   ON reputation_events (lawyer_id)

--- a/supabase/migrations/006_reputation_guards.sql
+++ b/supabase/migrations/006_reputation_guards.sql
@@ -1,11 +1,67 @@
 -- Migration 006: Reputation guards
--- Partial unique index on reputation_events for profile_completed one-time guard.
--- awardPoints() uses Supabase's built-in aggregate for upvote SUM (no custom RPC needed).
+-- Partial unique indexes for profile_completed (one-time per lawyer) and
+-- brief_generated (one-time per lawyer+matter) idempotency.
+-- Upvote caps are enforced via the custom RPC award_upvote_points (migration 007).
 
--- ── Partial unique index: profile_completed is one-time per lawyer ────────────
--- Prevents double-award even under concurrent requests.
--- The INSERT in awardPoints() will receive a 23505 unique violation if already awarded.
+-- ── profile_completed: one-time per lawyer ────────────────────────────────────
+DELETE FROM reputation_events
+WHERE id NOT IN (
+  SELECT DISTINCT ON (lawyer_id) id
+  FROM reputation_events
+  WHERE event_type = 'profile_completed'
+  ORDER BY lawyer_id, created_at ASC
+)
+AND event_type = 'profile_completed';
 
 CREATE UNIQUE INDEX IF NOT EXISTS reputation_events_profile_completed_once
   ON reputation_events (lawyer_id)
   WHERE event_type = 'profile_completed';
+
+-- ── brief_generated: one-time per (lawyer, matter) ───────────────────────────
+CREATE UNIQUE INDEX IF NOT EXISTS reputation_events_brief_generated_once
+  ON reputation_events (lawyer_id, matter_id)
+  WHERE event_type = 'brief_generated';
+
+-- ── award_upvote_points: atomic cap-enforced upvote award ─────────────────────
+-- Locks the lawyer row so concurrent upvotes cannot both read the same SUM
+-- and both award past the cap. Insert + increment happen in one transaction.
+-- Returns points actually awarded (0 if cap already reached).
+
+CREATE OR REPLACE FUNCTION award_upvote_points(
+  p_lawyer_id  UUID,
+  p_matter_id  UUID    DEFAULT NULL,
+  p_description TEXT   DEFAULT 'Field note upvoted',
+  p_points     INT     DEFAULT 10,
+  p_cap        INT     DEFAULT 200
+)
+RETURNS INT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_total     INT;
+  v_remaining INT;
+  v_award     INT;
+BEGIN
+  -- Lock the lawyer row for the duration of this transaction to serialize
+  -- concurrent upvote awards for the same lawyer.
+  PERFORM id FROM lawyers WHERE id = p_lawyer_id FOR UPDATE;
+
+  SELECT COALESCE(SUM(points), 0) INTO v_total
+  FROM reputation_events
+  WHERE lawyer_id = p_lawyer_id AND event_type = 'note_upvoted';
+
+  v_remaining := p_cap - v_total;
+  IF v_remaining <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  v_award := LEAST(p_points, v_remaining);
+
+  INSERT INTO reputation_events (lawyer_id, event_type, points, matter_id, description)
+  VALUES (p_lawyer_id, 'note_upvoted', v_award, p_matter_id, p_description);
+
+  UPDATE lawyers
+  SET reputation_score = reputation_score + v_award
+  WHERE id = p_lawyer_id;
+
+  RETURN v_award;
+END;
+$$;

--- a/supabase/migrations/006_reputation_guards.sql
+++ b/supabase/migrations/006_reputation_guards.sql
@@ -34,46 +34,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS reputation_events_brief_generated_once
   ON reputation_events (lawyer_id, matter_id)
   WHERE event_type = 'brief_generated';
 
--- ── award_upvote_points: atomic cap-enforced upvote award ─────────────────────
--- Locks the lawyer row so concurrent upvotes cannot both read the same SUM
--- and both award past the cap. Insert + increment happen in one transaction.
--- Returns points actually awarded (0 if cap already reached).
-
-CREATE OR REPLACE FUNCTION award_upvote_points(
-  p_lawyer_id  UUID,
-  p_matter_id  UUID    DEFAULT NULL,
-  p_description TEXT   DEFAULT 'Field note upvoted',
-  p_points     INT     DEFAULT 10,
-  p_cap        INT     DEFAULT 200
-)
-RETURNS INT LANGUAGE plpgsql SECURITY DEFINER AS $$
-DECLARE
-  v_total     INT;
-  v_remaining INT;
-  v_award     INT;
-BEGIN
-  -- Lock the lawyer row for the duration of this transaction to serialize
-  -- concurrent upvote awards for the same lawyer.
-  PERFORM id FROM lawyers WHERE id = p_lawyer_id FOR UPDATE;
-
-  SELECT COALESCE(SUM(points), 0) INTO v_total
-  FROM reputation_events
-  WHERE lawyer_id = p_lawyer_id AND event_type = 'note_upvoted';
-
-  v_remaining := p_cap - v_total;
-  IF v_remaining <= 0 THEN
-    RETURN 0;
-  END IF;
-
-  v_award := LEAST(p_points, v_remaining);
-
-  INSERT INTO reputation_events (lawyer_id, event_type, points, matter_id, description)
-  VALUES (p_lawyer_id, 'note_upvoted', v_award, p_matter_id, p_description);
-
-  UPDATE lawyers
-  SET reputation_score = reputation_score + v_award
-  WHERE id = p_lawyer_id;
-
-  RETURN v_award;
-END;
-$$;
+-- ── award_upvote_points: defined and hardened in migration 007 ────────────────
+-- Do not create the older SECURITY DEFINER version here: leaving this signature
+-- in place can expose EXECUTE to PUBLIC by default and can also cause overloaded
+-- RPC resolution issues once migration 007 introduces the canonical function.
+DROP FUNCTION IF EXISTS award_upvote_points(UUID, UUID, TEXT, INT, INT);

--- a/supabase/migrations/007_reputation_atomic.sql
+++ b/supabase/migrations/007_reputation_atomic.sql
@@ -1,14 +1,19 @@
 -- Migration 007: Atomic reputation awards + per-note upvote cap + source_id
 
 -- ── Add source_id to reputation_events ───────────────────────────────────────
--- Scopes upvote events to a specific field_note (or any source entity).
 ALTER TABLE reputation_events
   ADD COLUMN IF NOT EXISTS source_id UUID DEFAULT NULL;
 
--- ── award_reputation_event: atomic insert + increment in one transaction ──────
--- Replaces the two-step insert + increment_reputation_rpc pattern.
--- profile_completed and brief_generated callers rely on their unique indexes
--- to get 23505 on duplicate — this function does not handle ON CONFLICT itself.
+-- ── Index for award_upvote_points SUM query ───────────────────────────────────
+-- The upvote cap check filters on (lawyer_id, event_type, source_id).
+CREATE INDEX IF NOT EXISTS reputation_events_upvote_sum_idx
+  ON reputation_events (lawyer_id, source_id)
+  WHERE event_type = 'note_upvoted';
+
+-- ── award_reputation_event ────────────────────────────────────────────────────
+-- Inserts a reputation_events row and increments lawyers.reputation_score in
+-- one transaction. COALESCE(p_description, '') guards the NOT NULL constraint.
+-- search_path is fixed to prevent schema hijacking.
 
 CREATE OR REPLACE FUNCTION award_reputation_event(
   p_lawyer_id   UUID,
@@ -18,10 +23,21 @@ CREATE OR REPLACE FUNCTION award_reputation_event(
   p_source_id   UUID    DEFAULT NULL,
   p_description TEXT    DEFAULT NULL
 )
-RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
 BEGIN
   INSERT INTO reputation_events (lawyer_id, event_type, points, matter_id, source_id, description)
-  VALUES (p_lawyer_id, p_event_type, p_points, p_matter_id, p_source_id, p_description);
+  VALUES (
+    p_lawyer_id,
+    p_event_type,
+    p_points,
+    p_matter_id,
+    p_source_id,
+    COALESCE(p_description, '')
+  );
 
   UPDATE lawyers
   SET reputation_score = reputation_score + p_points
@@ -29,10 +45,15 @@ BEGIN
 END;
 $$;
 
--- ── award_upvote_points: per-note cap, fully atomic ───────────────────────────
--- Locks the lawyer row to serialize concurrent upvotes for the same lawyer.
--- Cap of 200 pts is scoped to (lawyer_id, source_id) — i.e. per field note.
--- Returns points actually awarded (0 if cap already reached for this note).
+-- Lock down: only the service role may call this function.
+REVOKE ALL ON FUNCTION award_reputation_event(UUID, TEXT, INT, UUID, UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION award_reputation_event(UUID, TEXT, INT, UUID, UUID, TEXT) TO service_role;
+
+-- ── award_upvote_points ───────────────────────────────────────────────────────
+-- Locks the lawyer row to serialize concurrent upvotes.
+-- Cap is scoped to (lawyer_id, source_id) — per field note.
+-- Returns points actually awarded (0 if cap already reached).
+-- search_path is fixed to prevent schema hijacking.
 
 CREATE OR REPLACE FUNCTION award_upvote_points(
   p_lawyer_id   UUID,
@@ -42,16 +63,18 @@ CREATE OR REPLACE FUNCTION award_upvote_points(
   p_points      INT     DEFAULT 10,
   p_cap         INT     DEFAULT 200
 )
-RETURNS INT LANGUAGE plpgsql SECURITY DEFINER AS $$
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
 DECLARE
   v_total     INT;
   v_remaining INT;
   v_award     INT;
 BEGIN
-  -- Serialize concurrent upvote awards for the same lawyer
   PERFORM id FROM lawyers WHERE id = p_lawyer_id FOR UPDATE;
 
-  -- Sum points already awarded for this specific note
   SELECT COALESCE(SUM(points), 0) INTO v_total
   FROM reputation_events
   WHERE lawyer_id = p_lawyer_id
@@ -66,7 +89,14 @@ BEGIN
   v_award := LEAST(p_points, v_remaining);
 
   INSERT INTO reputation_events (lawyer_id, event_type, points, matter_id, source_id, description)
-  VALUES (p_lawyer_id, 'note_upvoted', v_award, p_matter_id, p_source_id, p_description);
+  VALUES (
+    p_lawyer_id,
+    'note_upvoted',
+    v_award,
+    p_matter_id,
+    p_source_id,
+    COALESCE(p_description, 'Field note upvoted')
+  );
 
   UPDATE lawyers
   SET reputation_score = reputation_score + v_award
@@ -75,3 +105,7 @@ BEGIN
   RETURN v_award;
 END;
 $$;
+
+-- Lock down: only the service role may call this function.
+REVOKE ALL ON FUNCTION award_upvote_points(UUID, UUID, UUID, TEXT, INT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION award_upvote_points(UUID, UUID, UUID, TEXT, INT, INT) TO service_role;

--- a/supabase/migrations/007_reputation_atomic.sql
+++ b/supabase/migrations/007_reputation_atomic.sql
@@ -50,6 +50,10 @@ REVOKE ALL ON FUNCTION award_reputation_event(UUID, TEXT, INT, UUID, UUID, TEXT)
 GRANT EXECUTE ON FUNCTION award_reputation_event(UUID, TEXT, INT, UUID, UUID, TEXT) TO service_role;
 
 -- ── award_upvote_points ───────────────────────────────────────────────────────
+-- Drop the old signature from migration 006 (no p_source_id) so we don't
+-- accumulate overloads — PostgREST does not handle overloaded RPCs reliably.
+DROP FUNCTION IF EXISTS award_upvote_points(UUID, UUID, TEXT, INT, INT);
+
 -- Locks the lawyer row to serialize concurrent upvotes.
 -- Cap is scoped to (lawyer_id, source_id) — per field note.
 -- Returns points actually awarded (0 if cap already reached).

--- a/supabase/migrations/007_reputation_atomic.sql
+++ b/supabase/migrations/007_reputation_atomic.sql
@@ -1,0 +1,77 @@
+-- Migration 007: Atomic reputation awards + per-note upvote cap + source_id
+
+-- ── Add source_id to reputation_events ───────────────────────────────────────
+-- Scopes upvote events to a specific field_note (or any source entity).
+ALTER TABLE reputation_events
+  ADD COLUMN IF NOT EXISTS source_id UUID DEFAULT NULL;
+
+-- ── award_reputation_event: atomic insert + increment in one transaction ──────
+-- Replaces the two-step insert + increment_reputation_rpc pattern.
+-- profile_completed and brief_generated callers rely on their unique indexes
+-- to get 23505 on duplicate — this function does not handle ON CONFLICT itself.
+
+CREATE OR REPLACE FUNCTION award_reputation_event(
+  p_lawyer_id   UUID,
+  p_event_type  TEXT,
+  p_points      INT,
+  p_matter_id   UUID    DEFAULT NULL,
+  p_source_id   UUID    DEFAULT NULL,
+  p_description TEXT    DEFAULT NULL
+)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  INSERT INTO reputation_events (lawyer_id, event_type, points, matter_id, source_id, description)
+  VALUES (p_lawyer_id, p_event_type, p_points, p_matter_id, p_source_id, p_description);
+
+  UPDATE lawyers
+  SET reputation_score = reputation_score + p_points
+  WHERE id = p_lawyer_id;
+END;
+$$;
+
+-- ── award_upvote_points: per-note cap, fully atomic ───────────────────────────
+-- Locks the lawyer row to serialize concurrent upvotes for the same lawyer.
+-- Cap of 200 pts is scoped to (lawyer_id, source_id) — i.e. per field note.
+-- Returns points actually awarded (0 if cap already reached for this note).
+
+CREATE OR REPLACE FUNCTION award_upvote_points(
+  p_lawyer_id   UUID,
+  p_source_id   UUID,
+  p_matter_id   UUID    DEFAULT NULL,
+  p_description TEXT    DEFAULT 'Field note upvoted',
+  p_points      INT     DEFAULT 10,
+  p_cap         INT     DEFAULT 200
+)
+RETURNS INT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_total     INT;
+  v_remaining INT;
+  v_award     INT;
+BEGIN
+  -- Serialize concurrent upvote awards for the same lawyer
+  PERFORM id FROM lawyers WHERE id = p_lawyer_id FOR UPDATE;
+
+  -- Sum points already awarded for this specific note
+  SELECT COALESCE(SUM(points), 0) INTO v_total
+  FROM reputation_events
+  WHERE lawyer_id = p_lawyer_id
+    AND event_type = 'note_upvoted'
+    AND source_id  = p_source_id;
+
+  v_remaining := p_cap - v_total;
+  IF v_remaining <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  v_award := LEAST(p_points, v_remaining);
+
+  INSERT INTO reputation_events (lawyer_id, event_type, points, matter_id, source_id, description)
+  VALUES (p_lawyer_id, 'note_upvoted', v_award, p_matter_id, p_source_id, p_description);
+
+  UPDATE lawyers
+  SET reputation_score = reputation_score + v_award
+  WHERE id = p_lawyer_id;
+
+  RETURN v_award;
+END;
+$$;


### PR DESCRIPTION
## Summary

- `lib/reputation/awards.ts` — single source of truth for all point values, badge tiers, and `awardPoints()` with guards
- `app/api/reputation/route.ts` — leaderboard and per-lawyer event feed endpoints
- Wired `handoff_completed` (25pts) in Flow engine and `brief_generated` (50pts) in context generate route

## Changes

- **`lib/reputation/awards.ts`**
  - `REPUTATION_POINTS` map for all 8 event types
  - `BADGE_TIERS`: Contributor (0) → Rising Star (100) → Regional Expert (500) → Global Expert (1000) → Elite Partner (2500)
  - `getBadge(score)` — returns current tier label
  - `awardPoints()` — inserts reputation_events row + increments lawyers.reputation_score; guards: one-time check for `profile_completed`, cap check (200pts) for `note_upvoted`

- **`app/api/reputation/route.ts`**
  - `GET /api/reputation` — top 20 leaderboard with rank + badge
  - `GET /api/reputation?lawyer_id=xxx` — single lawyer score, badge, last 50 events

- **`lib/flow/engine.ts`** — replaced inline reputation insert/rpc with `awardPoints(handoff_completed)`
- **`app/api/context/generate/route.ts`** — awards `brief_generated` (50pts) to matter's lead lawyer when all jurisdiction briefs reach `ready` status

## Remaining triggers (wired in upcoming issues)
- `note_contributed` / `note_upvoted` → #32 field notes
- `match_accepted` → already in team route
- `profile_completed` → profile page (#34 polish)
- `cross_border_matter` → matter creation flow

## Test plan

- [ ] Route a task → receiving lawyer gains 25 pts in reputation_events
- [ ] Generate all briefs for a matter → lead lawyer gains 50 pts
- [ ] `GET /api/reputation` returns ranked list with badge labels
- [ ] `GET /api/reputation?lawyer_id=xxx` returns events + badge for that lawyer
- [ ] `profile_completed` awards only once per lawyer
- [ ] `note_upvoted` stops awarding after 200 total pts

Closes #30