### PR TITLE
feat(reputation): leaderboard page with chart and event feed (#31)

### DIFF
--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -1,7 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getBadge } from "@/lib/reputation/badges";
 
 const uuidSchema = z.string().uuid();
 
@@ -23,7 +22,10 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: "Invalid lawyer_id — must be a UUID" }, { status: 400 });
     }
     const lawyerId = parsed.data;
-    // Single lawyer: score + badge + recent events
+    // Single lawyer: score + events from the last 30 days (matches chart window)
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
     const [lawyerResult, eventsResult] = await Promise.all([
       supabase
         .from("lawyers")
@@ -34,8 +36,9 @@ export async function GET(request: Request) {
         .from("reputation_events")
         .select("id, event_type, points, description, matter_id, created_at")
         .eq("lawyer_id", lawyerId)
+        .gte("created_at", thirtyDaysAgo.toISOString())
         .order("created_at", { ascending: false })
-        .limit(50),
+        .limit(100),
     ]);
 
     if (lawyerResult.error) {
@@ -50,10 +53,7 @@ export async function GET(request: Request) {
     }
 
     return NextResponse.json({
-      lawyer: {
-        ...lawyerResult.data,
-        badge: getBadge(lawyerResult.data.reputation_score ?? 0),
-      },
+      lawyer: lawyerResult.data,
       events: eventsResult.data ?? [],
     });
   }
@@ -71,7 +71,6 @@ export async function GET(request: Request) {
   const enriched = (leaderboard ?? []).map((l, idx) => ({
     ...l,
     rank: idx + 1,
-    badge: getBadge(l.reputation_score ?? 0),
   }));
 
   return NextResponse.json({ leaderboard: enriched });

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getBadge } from "@/lib/reputation/awards";
+import { getBadge } from "@/lib/reputation/badges";
 
 const uuidSchema = z.string().uuid();
 
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
         .single(),
       supabase
         .from("reputation_events")
-        .select("id, event_type, points, created_at")
+        .select("id, event_type, points, description, matter_id, created_at")
         .eq("lawyer_id", lawyerId)
         .order("created_at", { ascending: false })
         .limit(50),

--- a/app/reputation/_components/EventFeed.tsx
+++ b/app/reputation/_components/EventFeed.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Zap, FileText, Users, Star, ArrowRight, CheckCircle2, UserCheck } from "lucide-react";
+import { getBadge } from "@/lib/reputation/badges";
+
+interface ReputationEvent {
+  id: string;
+  event_type: string;
+  points: number;
+  description: string;
+  matter_id: string | null;
+  created_at: string;
+}
+
+interface LawyerDetail {
+  id: string;
+  full_name: string;
+  office_city: string;
+  reputation_score: number;
+  avatar_url: string | null;
+}
+
+interface Props {
+  lawyer: LawyerDetail;
+  events: ReputationEvent[];
+}
+
+const EVENT_ICONS: Record<string, React.ElementType> = {
+  matter_joined: Users,
+  brief_generated: FileText,
+  note_contributed: Star,
+  note_upvoted: Star,
+  handoff_completed: ArrowRight,
+  match_accepted: UserCheck,
+  profile_completed: CheckCircle2,
+  cross_border_matter: Zap,
+};
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export default function EventFeed({ lawyer, events }: Props) {
+  const badge = getBadge(lawyer.reputation_score);
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-4 border-b border-gray-100 flex items-center justify-between">
+        <div>
+          <p className="font-semibold text-gray-900 text-sm">{lawyer.full_name}</p>
+          <p className="text-xs text-gray-400">{lawyer.office_city}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-lg font-bold text-brand-purple">
+            {lawyer.reputation_score.toLocaleString()}
+          </p>
+          <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${badge.color}`}>
+            {badge.label}
+          </span>
+        </div>
+      </div>
+
+      {/* Events */}
+      <div className="divide-y divide-gray-50 max-h-[420px] overflow-y-auto">
+        {events.length === 0 ? (
+          <p className="text-xs text-gray-400 text-center py-8">No reputation events yet</p>
+        ) : (
+          events.map((event) => {
+            const Icon = EVENT_ICONS[event.event_type] ?? Zap;
+            return (
+              <div key={event.id} className="px-4 py-3 flex items-start gap-3">
+                <div className="w-7 h-7 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+                  <Icon className="w-3.5 h-3.5 text-brand-purple" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs text-gray-700 leading-snug">{event.description}</p>
+                  <p className="text-[10px] text-gray-400 mt-0.5">{relativeTime(event.created_at)}</p>
+                </div>
+                <span className="text-xs font-semibold text-green-600 flex-shrink-0">
+                  +{event.points}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/reputation/_components/LeaderboardTable.tsx
+++ b/app/reputation/_components/LeaderboardTable.tsx
@@ -51,8 +51,12 @@ export default function LeaderboardTable({ leaderboard, selectedId, onSelect }: 
             return (
               <tr
                 key={entry.id}
+                role="button"
+                tabIndex={0}
+                aria-pressed={isSelected}
                 onClick={() => onSelect(entry.id)}
-                className={`cursor-pointer transition-colors hover:bg-gray-50 ${
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(entry.id); } }}
+                className={`cursor-pointer transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-purple ${
                   isSelected ? "bg-brand-purple/5 hover:bg-brand-purple/5" : ""
                 }`}
               >

--- a/app/reputation/_components/LeaderboardTable.tsx
+++ b/app/reputation/_components/LeaderboardTable.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { getBadge } from "@/lib/reputation/badges";
+
+interface LeaderboardEntry {
+  id: string;
+  full_name: string;
+  office_city: string;
+  office_country: string;
+  reputation_score: number;
+  avatar_url: string | null;
+  matters_count: number;
+  rank: number;
+}
+
+interface Props {
+  leaderboard: LeaderboardEntry[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function Initials({ name }: { name: string }) {
+  const parts = name.trim().split(" ");
+  return <>{parts.length >= 2 ? `${parts[0][0]}${parts[parts.length - 1][0]}` : name[0]}</>;
+}
+
+const RANK_STYLES: Record<number, string> = {
+  1: "text-yellow-600 font-bold",
+  2: "text-gray-400 font-bold",
+  3: "text-orange-500 font-bold",
+};
+
+export default function LeaderboardTable({ leaderboard, selectedId, onSelect }: Props) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-100 bg-gray-50">
+            <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 w-10">#</th>
+            <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500">Lawyer</th>
+            <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 hidden sm:table-cell">Badge</th>
+            <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 hidden sm:table-cell">Matters</th>
+            <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500">Score</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-50">
+          {leaderboard.map((entry) => {
+            const badge = getBadge(entry.reputation_score);
+            const isSelected = entry.id === selectedId;
+
+            return (
+              <tr
+                key={entry.id}
+                onClick={() => onSelect(entry.id)}
+                className={`cursor-pointer transition-colors hover:bg-gray-50 ${
+                  isSelected ? "bg-brand-purple/5 hover:bg-brand-purple/5" : ""
+                }`}
+              >
+                {/* Rank */}
+                <td className="px-4 py-3 text-sm">
+                  <span className={RANK_STYLES[entry.rank] ?? "text-gray-400 font-medium"}>
+                    {entry.rank}
+                  </span>
+                </td>
+
+                {/* Avatar + name */}
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
+                      <span className="text-[11px] font-semibold text-brand-purple">
+                        <Initials name={entry.full_name} />
+                      </span>
+                    </div>
+                    <div>
+                      <p className="font-medium text-gray-900 leading-tight">{entry.full_name}</p>
+                      <p className="text-xs text-gray-400">{entry.office_city}, {entry.office_country}</p>
+                    </div>
+                  </div>
+                </td>
+
+                {/* Badge */}
+                <td className="px-4 py-3 hidden sm:table-cell">
+                  <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${badge.color}`}>
+                    {badge.label}
+                  </span>
+                </td>
+
+                {/* Matters */}
+                <td className="px-4 py-3 text-right text-gray-500 hidden sm:table-cell">
+                  {entry.matters_count ?? 0}
+                </td>
+
+                {/* Score */}
+                <td className="px-4 py-3 text-right">
+                  <span className={`font-semibold ${isSelected ? "text-brand-purple" : "text-gray-900"}`}>
+                    {entry.reputation_score.toLocaleString()}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/reputation/_components/ReputationChart.tsx
+++ b/app/reputation/_components/ReputationChart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+interface ReputationEvent {
+  points: number;
+  created_at: string;
+}
+
+interface Props {
+  events: ReputationEvent[];
+  currentScore: number;
+}
+
+export default function ReputationChart({ events, currentScore }: Props) {
+  // Build cumulative score timeline from oldest to newest
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+
+  let running = currentScore;
+  // Walk backwards to reconstruct past scores
+  const reversed = [...sorted].reverse().map((e) => {
+    const score = running;
+    running -= e.points;
+    return { date: e.created_at, score };
+  });
+
+  const chartData = reversed.reverse().map((d) => ({
+    date: new Date(d.date).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+    score: d.score,
+  }));
+
+  if (chartData.length < 2) return null;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-4">
+      <p className="text-xs font-semibold text-gray-500 mb-3">Score over time</p>
+      <ResponsiveContainer width="100%" height={120}>
+        <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+          <defs>
+            <linearGradient id="scoreGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#702082" stopOpacity={0.15} />
+              <stop offset="95%" stopColor="#702082" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 10, fill: "#9ca3af" }}
+            tickLine={false}
+            axisLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            tick={{ fontSize: 10, fill: "#9ca3af" }}
+            tickLine={false}
+            axisLine={false}
+            width={40}
+          />
+          <Tooltip
+            contentStyle={{ fontSize: 11, borderRadius: 8, border: "1px solid #e5e7eb" }}
+            formatter={(v: number) => [v.toLocaleString(), "Score"]}
+          />
+          <Area
+            type="monotone"
+            dataKey="score"
+            stroke="#702082"
+            strokeWidth={2}
+            fill="url(#scoreGradient)"
+            dot={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/app/reputation/_components/ReputationChart.tsx
+++ b/app/reputation/_components/ReputationChart.tsx
@@ -34,7 +34,7 @@ export default function ReputationChart({ events, currentScore }: Props) {
   });
 
   const chartData = reversed.reverse().map((d) => ({
-    date: new Date(d.date).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+    date: new Date(d.date).toLocaleDateString("en-GB", { month: "short", day: "numeric" }),
     score: d.score,
   }));
 
@@ -42,7 +42,7 @@ export default function ReputationChart({ events, currentScore }: Props) {
 
   return (
     <div className="bg-white border border-gray-200 rounded-xl p-4">
-      <p className="text-xs font-semibold text-gray-500 mb-3">Score over time</p>
+      <p className="text-xs font-semibold text-gray-500 mb-3">Last 30 days</p>
       <ResponsiveContainer width="100%" height={120}>
         <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
           <defs>

--- a/app/reputation/page.tsx
+++ b/app/reputation/page.tsx
@@ -1,75 +1,79 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import LeaderboardTable from "./_components/LeaderboardTable";
 import EventFeed from "./_components/EventFeed";
 import ReputationChart from "./_components/ReputationChart";
+import type { Lawyer, ReputationEvent } from "@/types";
 
-interface LeaderboardEntry {
-  id: string;
-  full_name: string;
-  office_city: string;
-  office_country: string;
-  reputation_score: number;
-  avatar_url: string | null;
-  matters_count: number;
-  rank: number;
-}
+// Shape returned by GET /api/reputation (leaderboard entry)
+type LeaderboardEntry = Pick<
+  Lawyer,
+  "id" | "full_name" | "office_city" | "office_country" | "reputation_score" | "avatar_url" | "matters_count"
+> & { rank: number };
 
-interface ReputationEvent {
-  id: string;
-  event_type: string;
-  points: number;
-  description: string;
-  matter_id: string | null;
-  created_at: string;
-}
-
-interface LawyerDetail {
-  id: string;
-  full_name: string;
-  office_city: string;
-  reputation_score: number;
-  avatar_url: string | null;
-}
+// Shape returned by GET /api/reputation?lawyer_id=xxx
+type LawyerDetail = Pick<Lawyer, "id" | "full_name" | "office_city" | "reputation_score" | "avatar_url">;
 
 export default function ReputationPage() {
+  const router = useRouter();
+
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const [loadingBoard, setLoadingBoard] = useState(true);
+  const [boardError, setBoardError] = useState<string | null>(null);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedLawyer, setSelectedLawyer] = useState<LawyerDetail | null>(null);
   const [events, setEvents] = useState<ReputationEvent[]>([]);
   const [loadingDetail, setLoadingDetail] = useState(false);
 
+  // Track latest request to discard stale responses from rapid row clicks
+  const latestRequestId = useRef(0);
+
   // Fetch leaderboard on mount
   useEffect(() => {
     fetch("/api/reputation")
-      .then((r) => r.json())
-      .then((data) => {
-        setLeaderboard(data.leaderboard ?? []);
-        // Auto-select #1 on load
-        if (data.leaderboard?.length) {
-          setSelectedId(data.leaderboard[0].id);
-        }
+      .then((r) => {
+        if (r.status === 401) { router.push("/login"); return null; }
+        if (!r.ok) throw new Error(`Failed to load leaderboard (${r.status})`);
+        return r.json();
       })
+      .then((data) => {
+        if (!data) return;
+        setLeaderboard(data.leaderboard ?? []);
+        if (data.leaderboard?.length) setSelectedId(data.leaderboard[0].id);
+      })
+      .catch((err) => setBoardError(err.message))
       .finally(() => setLoadingBoard(false));
-  }, []);
+  }, [router]);
 
-  // Fetch detail when selection changes
+  // Fetch detail when selection changes — AbortController + request ID guard
   const fetchDetail = useCallback(async (lawyerId: string) => {
+    const requestId = ++latestRequestId.current;
+
+    // Clear stale state immediately on selection change
+    setSelectedLawyer(null);
+    setEvents([]);
     setLoadingDetail(true);
+
     try {
       const res = await fetch(`/api/reputation?lawyer_id=${lawyerId}`);
+      if (requestId !== latestRequestId.current) return; // superseded
+
+      if (res.status === 401) { router.push("/login"); return; }
       if (!res.ok) return;
+
       const data = await res.json();
+      if (requestId !== latestRequestId.current) return; // superseded
+
       setSelectedLawyer(data.lawyer);
       setEvents(data.events ?? []);
     } finally {
-      setLoadingDetail(false);
+      if (requestId === latestRequestId.current) setLoadingDetail(false);
     }
-  }, []);
+  }, [router]);
 
   useEffect(() => {
     if (selectedId) fetchDetail(selectedId);
@@ -89,6 +93,8 @@ export default function ReputationPage() {
         <div className="flex items-center justify-center py-24">
           <Loader2 className="w-6 h-6 animate-spin text-brand-purple" />
         </div>
+      ) : boardError ? (
+        <div className="text-center py-16 text-sm text-red-500">{boardError}</div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Leaderboard — takes 2 of 3 columns */}

--- a/app/reputation/page.tsx
+++ b/app/reputation/page.tsx
@@ -49,7 +49,7 @@ export default function ReputationPage() {
       .finally(() => setLoadingBoard(false));
   }, [router]);
 
-  // Fetch detail when selection changes — AbortController + request ID guard
+  // Fetch detail when selection changes — request ID guard prevents stale responses from updating state
   const fetchDetail = useCallback(async (lawyerId: string) => {
     const requestId = ++latestRequestId.current;
 

--- a/app/reputation/page.tsx
+++ b/app/reputation/page.tsx
@@ -1,8 +1,123 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Loader2 } from "lucide-react";
+import LeaderboardTable from "./_components/LeaderboardTable";
+import EventFeed from "./_components/EventFeed";
+import ReputationChart from "./_components/ReputationChart";
+
+interface LeaderboardEntry {
+  id: string;
+  full_name: string;
+  office_city: string;
+  office_country: string;
+  reputation_score: number;
+  avatar_url: string | null;
+  matters_count: number;
+  rank: number;
+}
+
+interface ReputationEvent {
+  id: string;
+  event_type: string;
+  points: number;
+  description: string;
+  matter_id: string | null;
+  created_at: string;
+}
+
+interface LawyerDetail {
+  id: string;
+  full_name: string;
+  office_city: string;
+  reputation_score: number;
+  avatar_url: string | null;
+}
+
 export default function ReputationPage() {
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [loadingBoard, setLoadingBoard] = useState(true);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedLawyer, setSelectedLawyer] = useState<LawyerDetail | null>(null);
+  const [events, setEvents] = useState<ReputationEvent[]>([]);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+
+  // Fetch leaderboard on mount
+  useEffect(() => {
+    fetch("/api/reputation")
+      .then((r) => r.json())
+      .then((data) => {
+        setLeaderboard(data.leaderboard ?? []);
+        // Auto-select #1 on load
+        if (data.leaderboard?.length) {
+          setSelectedId(data.leaderboard[0].id);
+        }
+      })
+      .finally(() => setLoadingBoard(false));
+  }, []);
+
+  // Fetch detail when selection changes
+  const fetchDetail = useCallback(async (lawyerId: string) => {
+    setLoadingDetail(true);
+    try {
+      const res = await fetch(`/api/reputation?lawyer_id=${lawyerId}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setSelectedLawyer(data.lawyer);
+      setEvents(data.events ?? []);
+    } finally {
+      setLoadingDetail(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedId) fetchDetail(selectedId);
+  }, [selectedId, fetchDetail]);
+
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold text-white">Reputation</h1>
-      <p className="text-slate-400 mt-2">Coming soon — Phase 3</p>
+    <div className="max-w-6xl mx-auto px-4 py-8 space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900">Reputation</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Firm-wide leaderboard — earned through cross-border collaboration
+        </p>
+      </div>
+
+      {loadingBoard ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="w-6 h-6 animate-spin text-brand-purple" />
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Leaderboard — takes 2 of 3 columns */}
+          <div className="lg:col-span-2">
+            <LeaderboardTable
+              leaderboard={leaderboard}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+            />
+          </div>
+
+          {/* Detail panel */}
+          <div className="space-y-4">
+            {loadingDetail ? (
+              <div className="bg-white border border-gray-200 rounded-xl flex items-center justify-center py-16">
+                <Loader2 className="w-5 h-5 animate-spin text-brand-purple" />
+              </div>
+            ) : selectedLawyer ? (
+              <>
+                <ReputationChart
+                  events={events}
+                  currentScore={selectedLawyer.reputation_score}
+                />
+                <EventFeed lawyer={selectedLawyer} events={events} />
+              </>
+            ) : null}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -19,22 +19,9 @@ export type ReputationEventType = keyof typeof REPUTATION_POINTS;
 // Max points a single field note can earn its author from upvotes
 export const NOTE_UPVOTE_CAP = 200;
 
-// ─── Badge tiers ─────────────────────────────────────────────────────────────
-
-export const BADGE_TIERS = [
-  { label: "Contributor", min: 0 },
-  { label: "Rising Star", min: 100 },
-  { label: "Regional Expert", min: 500 },
-  { label: "Global Expert", min: 1000 },
-  { label: "Elite Partner", min: 2500 },
-] as const;
-
-export type BadgeTier = typeof BADGE_TIERS[number]["label"];
-
-export function getBadge(score: number): BadgeTier {
-  const tier = [...BADGE_TIERS].reverse().find((t) => score >= t.min);
-  return tier?.label ?? "Contributor";
-}
+// ─── Badge tiers (re-exported from client-safe badges.ts) ───────────────────
+export { BADGE_TIERS, getBadge } from "@/lib/reputation/badges";
+export type { BadgeTier } from "@/lib/reputation/badges";
 
 // ─── Core award function ──────────────────────────────────────────────────────
 

--- a/lib/reputation/badges.ts
+++ b/lib/reputation/badges.ts
@@ -1,0 +1,13 @@
+export const BADGE_TIERS = [
+  { label: "Contributor", min: 0, color: "text-gray-500 bg-gray-100" },
+  { label: "Rising Star", min: 100, color: "text-blue-600 bg-blue-50" },
+  { label: "Regional Expert", min: 500, color: "text-brand-purple bg-brand-purple/10" },
+  { label: "Global Expert", min: 1000, color: "text-orange-600 bg-orange-50" },
+  { label: "Elite Partner", min: 2500, color: "text-yellow-700 bg-yellow-50" },
+] as const;
+
+export type BadgeTier = typeof BADGE_TIERS[number]["label"];
+
+export function getBadge(score: number): (typeof BADGE_TIERS)[number] {
+  return [...BADGE_TIERS].reverse().find((t) => score >= t.min) ?? BADGE_TIERS[0];
+}


### PR DESCRIPTION
## Summary

- Reputation leaderboard page at `/reputation` — firm-wide top 20, click any row to see score history and event feed
- Extracted badge logic to `lib/reputation/badges.ts` (client-safe, no server-only dependency)

## Components

- **`LeaderboardTable`** — ranked table with gold/silver/bronze styling for top 3, badge pills (colour-coded by tier), click-to-select row highlighting
- **`EventFeed`** — per-lawyer recent events with type icons, `+N pts` in green, relative timestamps, badge + score header
- **`ReputationChart`** — recharts `AreaChart` of cumulative score over time, reconstructed from event history

## Fixes (post-review)

- Added missing `description` and `matter_id` fields to events SELECT — event feed was showing blank descriptions
- Changed `getBadge` import in API route from `awards.ts` (server-only) to `badges.ts` (client-safe)

## Demo impact

Satisfies demo step: *"Reputation leaderboard: Isabella #3 firm-wide. Marcus jumped 340→410."*
Auto-selects #1 on load. Click any row for drill-down. Chart makes score growth visible.

## Test plan

- [ ] `/reputation` loads and shows top 20 ranked lawyers
- [ ] Top 3 have gold/silver/bronze rank numbers
- [ ] Badge pill matches tier for each lawyer's score
- [ ] Clicking a row loads event feed and chart in right panel
- [ ] Event feed shows descriptions (not blank)
- [ ] Chart renders only when lawyer has ≥2 events
- [ ] Score reconstructs correctly from cumulative events

Closes #31