### PR TITLE
feat(field-notes): browse, contribute, and upvote jurisdiction knowledge base

### DIFF
--- a/app/api/field-notes/[id]/upvote/route.ts
+++ b/app/api/field-notes/[id]/upvote/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { awardPoints } from "@/lib/reputation/awards";
+
+const uuidSchema = z.string().uuid();
+
+// POST /api/field-notes/[id]/upvote
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const idParsed = uuidSchema.safeParse(params.id);
+  if (!idParsed.success) {
+    return NextResponse.json({ error: "Invalid note id" }, { status: 400 });
+  }
+  const noteId = idParsed.data;
+
+  // Authenticate upvoter
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const service = createServiceClient();
+
+  // Resolve upvoter's lawyer row
+  const { data: upvoter, error: upvoterError } = await service
+    .from("lawyers")
+    .select("id")
+    .eq("email", user.email)
+    .maybeSingle();
+
+  if (upvoterError || !upvoter) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch the note to get author + current upvote count
+  const { data: note, error: noteError } = await service
+    .from("field_notes")
+    .select("id, author_id, upvotes, title")
+    .eq("id", noteId)
+    .single();
+
+  if (noteError || !note) {
+    return NextResponse.json({ error: "Note not found" }, { status: 404 });
+  }
+
+  // Block self-upvote
+  if (upvoter.id === note.author_id) {
+    return NextResponse.json({ error: "Cannot upvote your own note" }, { status: 400 });
+  }
+
+  // Increment the cosmetic upvote counter (service role bypasses author-only RLS)
+  const { error: updateError } = await service
+    .from("field_notes")
+    .update({ upvotes: note.upvotes + 1 })
+    .eq("id", noteId);
+
+  if (updateError) {
+    return NextResponse.json({ error: "Failed to record upvote" }, { status: 500 });
+  }
+
+  // Award points to the AUTHOR — atomic cap enforced by award_upvote_points RPC
+  await awardPoints({
+    lawyer_id: note.author_id,
+    event_type: "note_upvoted",
+    source_id: noteId,
+    description: `Field note upvoted: ${note.title}`,
+  });
+
+  return NextResponse.json({ upvotes: note.upvotes + 1 });
+}

--- a/app/api/field-notes/route.ts
+++ b/app/api/field-notes/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { awardPoints } from "@/lib/reputation/awards";
+
+const JURISDICTIONS: Record<string, string> = {
+  BR: "Brazil",
+  CO: "Colombia",
+  DE: "Germany",
+  EU: "European Union",
+  MX: "Mexico",
+  US: "United States",
+};
+
+const createNoteSchema = z.object({
+  jurisdiction_code: z.string().min(2).max(10).transform((s) => s.trim().toUpperCase()),
+  title: z.string().min(1, "Title is required").max(200),
+  content: z.string().min(1, "Content is required"),
+  matter_type: z.string().optional().nullable(),
+  visibility: z.enum(["firm", "private"]).default("firm"),
+});
+
+async function getAuthenticatedLawyer() {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email) return null;
+
+  const service = createServiceClient();
+  const { data: lawyer, error } = await service
+    .from("lawyers")
+    .select("id, email")
+    .eq("email", user.email)
+    .maybeSingle();
+
+  if (error || !lawyer) return null;
+  return lawyer;
+}
+
+// GET /api/field-notes?jurisdiction=CO&q=FDI
+export async function GET(req: Request) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const jurisdiction = searchParams.get("jurisdiction")?.trim().toUpperCase() || null;
+  const q = searchParams.get("q")?.trim() || null;
+
+  let query = supabase
+    .from("field_notes")
+    .select("id, jurisdiction_code, jurisdiction_name, title, content, matter_type, upvotes, created_at, author_id, author:lawyers(id, full_name, office_city)")
+    .eq("visibility", "firm")
+    .order("upvotes", { ascending: false })
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (jurisdiction) query = query.eq("jurisdiction_code", jurisdiction);
+  if (q) query = query.or(`title.ilike.%${q}%,content.ilike.%${q}%`);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json(data ?? []);
+}
+
+// POST /api/field-notes — create note + award 40 pts to author
+export async function POST(req: Request) {
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createNoteSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const { jurisdiction_code, title, content, matter_type, visibility } = parsed.data;
+  const jurisdiction_name = JURISDICTIONS[jurisdiction_code] ?? jurisdiction_code;
+
+  const service = createServiceClient();
+  const { data: note, error } = await service
+    .from("field_notes")
+    .insert({
+      author_id: lawyer.id,
+      jurisdiction_code,
+      jurisdiction_name,
+      title,
+      content,
+      matter_type: matter_type ?? null,
+      visibility,
+    })
+    .select("id, jurisdiction_code, jurisdiction_name, title, content, upvotes, created_at")
+    .single();
+
+  if (error || !note) {
+    return NextResponse.json({ error: "Failed to create note" }, { status: 500 });
+  }
+
+  await awardPoints({
+    lawyer_id: lawyer.id,
+    event_type: "note_contributed",
+    description: `Contributed field note: ${title}`,
+  });
+
+  return NextResponse.json(note, { status: 201 });
+}

--- a/app/field-notes/new/page.tsx
+++ b/app/field-notes/new/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+const JURISDICTIONS = [
+  { code: "BR", name: "Brazil" },
+  { code: "CO", name: "Colombia" },
+  { code: "DE", name: "Germany" },
+  { code: "EU", name: "European Union" },
+  { code: "MX", name: "Mexico" },
+  { code: "US", name: "United States" },
+];
+
+const MATTER_TYPES = [
+  "M&A",
+  "Regulatory",
+  "Litigation",
+  "Employment",
+  "IP",
+  "Data Privacy",
+  "Finance",
+  "Real Estate",
+];
+
+export default function NewFieldNotePage() {
+  const router = useRouter();
+
+  const [jurisdiction, setJurisdiction] = useState("");
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [matterType, setMatterType] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!jurisdiction || !title.trim() || !content.trim()) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/field-notes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jurisdiction_code: jurisdiction,
+          title: title.trim(),
+          content: content.trim(),
+          matter_type: matterType || null,
+          visibility: "firm",
+        }),
+      });
+
+      if (res.status === 401) { router.push("/login"); return; }
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error ?? "Failed to create note");
+        return;
+      }
+
+      router.push("/field-notes");
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      {/* Back */}
+      <Link
+        href="/field-notes"
+        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-900 mb-6 transition-colors"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Back to Field Notes
+      </Link>
+
+      <div className="bg-white border border-gray-200 rounded-xl p-6">
+        <h1 className="text-xl font-semibold text-gray-900 mb-1">Contribute a Field Note</h1>
+        <p className="text-sm text-gray-500 mb-6">
+          Share practical jurisdiction intelligence with the firm. Earns 40 reputation points.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* Jurisdiction */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              Jurisdiction <span className="text-red-500">*</span>
+            </label>
+            <select
+              value={jurisdiction}
+              onChange={(e) => setJurisdiction(e.target.value)}
+              required
+              className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-brand-purple/40 bg-white"
+            >
+              <option value="">Select a jurisdiction</option>
+              {JURISDICTIONS.map((j) => (
+                <option key={j.code} value={j.code}>{j.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Title */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Colombia FDI restrictions for foreign investors"
+              required
+              maxLength={200}
+              className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-brand-purple/40"
+            />
+          </div>
+
+          {/* Matter type (optional) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              Matter type <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <select
+              value={matterType}
+              onChange={(e) => setMatterType(e.target.value)}
+              className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-brand-purple/40 bg-white"
+            >
+              <option value="">Any</option>
+              {MATTER_TYPES.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Content */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              Content <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Share what you know — regulations, cultural norms, practical tips for working in this jurisdiction..."
+              required
+              rows={8}
+              className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-brand-purple/40 resize-y"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-500">{error}</p>
+          )}
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={submitting || !jurisdiction || !title.trim() || !content.trim()}
+              className="flex items-center gap-2 px-5 py-2.5 bg-brand-purple text-white text-sm font-medium rounded-lg hover:bg-brand-purple/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+              Publish note
+            </button>
+            <Link
+              href="/field-notes"
+              className="px-5 py-2.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              Cancel
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/field-notes/page.tsx
+++ b/app/field-notes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2, ChevronUp, Plus, Search } from "lucide-react";
 import Link from "next/link";
@@ -38,7 +38,7 @@ function relativeTime(iso: string): string {
   return new Date(iso).toLocaleDateString("en-GB", { month: "short", day: "numeric" });
 }
 
-export default function FieldNotesPage() {
+function FieldNotesContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -207,5 +207,17 @@ export default function FieldNotesPage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function FieldNotesPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-24">
+        <Loader2 className="w-6 h-6 animate-spin text-brand-purple" />
+      </div>
+    }>
+      <FieldNotesContent />
+    </Suspense>
   );
 }

--- a/app/field-notes/page.tsx
+++ b/app/field-notes/page.tsx
@@ -1,8 +1,211 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Loader2, ChevronUp, Plus, Search } from "lucide-react";
+import Link from "next/link";
+import type { FieldNote, Lawyer } from "@/types";
+
+type NoteWithAuthor = Pick<
+  FieldNote,
+  "id" | "jurisdiction_code" | "jurisdiction_name" | "title" | "content" | "matter_type" | "upvotes" | "created_at" | "author_id"
+> & { author: Pick<Lawyer, "id" | "full_name" | "office_city"> | null };
+
+const JURISDICTIONS = [
+  { code: "BR", name: "Brazil" },
+  { code: "CO", name: "Colombia" },
+  { code: "DE", name: "Germany" },
+  { code: "EU", name: "European Union" },
+  { code: "MX", name: "Mexico" },
+  { code: "US", name: "United States" },
+];
+
+const JURISDICTION_COLORS: Record<string, string> = {
+  BR: "bg-green-100 text-green-700",
+  CO: "bg-yellow-100 text-yellow-700",
+  DE: "bg-blue-100 text-blue-700",
+  EU: "bg-indigo-100 text-indigo-700",
+  MX: "bg-red-100 text-red-700",
+  US: "bg-gray-100 text-gray-600",
+};
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString("en-GB", { month: "short", day: "numeric" });
+}
+
 export default function FieldNotesPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [notes, setNotes] = useState<NoteWithAuthor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [upvoting, setUpvoting] = useState<string | null>(null);
+
+  const jurisdiction = searchParams.get("jurisdiction") || "";
+  const q = searchParams.get("q") || "";
+  const [search, setSearch] = useState(q);
+
+  const fetchNotes = useCallback(async (jur: string, query: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (jur) params.set("jurisdiction", jur);
+      if (query) params.set("q", query);
+      const res = await fetch(`/api/field-notes?${params.toString()}`);
+      if (res.status === 401) { router.push("/login"); return; }
+      if (!res.ok) throw new Error(`Failed to load notes (${res.status})`);
+      setNotes(await res.json());
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    fetchNotes(jurisdiction, q);
+  }, [jurisdiction, q, fetchNotes]);
+
+  function applyFilter(newJur: string, newQ: string) {
+    const params = new URLSearchParams();
+    if (newJur) params.set("jurisdiction", newJur);
+    if (newQ) params.set("q", newQ);
+    router.push(`/field-notes?${params.toString()}`);
+  }
+
+  async function handleUpvote(noteId: string) {
+    if (upvoting) return;
+    setUpvoting(noteId);
+    try {
+      const res = await fetch(`/api/field-notes/${noteId}/upvote`, { method: "POST" });
+      if (res.status === 400) {
+        const body = await res.json();
+        alert(body.error);
+        return;
+      }
+      if (!res.ok) return;
+      const { upvotes } = await res.json();
+      setNotes((prev) =>
+        prev.map((n) => (n.id === noteId ? { ...n, upvotes } : n))
+      );
+    } finally {
+      setUpvoting(null);
+    }
+  }
+
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold text-white">Field Notes</h1>
-      <p className="text-slate-400 mt-2">Coming soon — Phase 3</p>
+    <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Field Notes</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Jurisdiction intelligence contributed by lawyers across the firm
+          </p>
+        </div>
+        <Link
+          href="/field-notes/new"
+          className="flex items-center gap-2 px-4 py-2 bg-brand-purple text-white text-sm font-medium rounded-lg hover:bg-brand-purple/90 transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Contribute
+        </Link>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search notes..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") applyFilter(jurisdiction, search); }}
+            onBlur={() => { if (search !== q) applyFilter(jurisdiction, search); }}
+            className="w-full pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-purple/40"
+          />
+        </div>
+        <select
+          value={jurisdiction}
+          onChange={(e) => applyFilter(e.target.value, q)}
+          className="text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-purple/40 bg-white"
+        >
+          <option value="">All jurisdictions</option>
+          {JURISDICTIONS.map((j) => (
+            <option key={j.code} value={j.code}>{j.name}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Notes */}
+      {loading ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="w-6 h-6 animate-spin text-brand-purple" />
+        </div>
+      ) : error ? (
+        <div className="text-center py-16 text-sm text-red-500">{error}</div>
+      ) : notes.length === 0 ? (
+        <div className="text-center py-16 text-sm text-gray-400">
+          {jurisdiction || q ? "No notes match your filters." : "No notes yet — be the first to contribute."}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {notes.map((note) => (
+            <div
+              key={note.id}
+              className="bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3"
+            >
+              {/* Top row */}
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <span
+                    className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${
+                      JURISDICTION_COLORS[note.jurisdiction_code] ?? "bg-gray-100 text-gray-600"
+                    }`}
+                  >
+                    {note.jurisdiction_name}
+                  </span>
+                  <h3 className="font-semibold text-gray-900 text-sm mt-2 leading-snug">
+                    {note.title}
+                  </h3>
+                </div>
+                <button
+                  onClick={() => handleUpvote(note.id)}
+                  disabled={upvoting === note.id}
+                  className="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border border-gray-200 hover:border-brand-purple/40 hover:bg-brand-purple/5 transition-colors disabled:opacity-50 flex-shrink-0"
+                  aria-label={`Upvote: ${note.upvotes} votes`}
+                >
+                  {upvoting === note.id ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin text-brand-purple" />
+                  ) : (
+                    <ChevronUp className="w-3.5 h-3.5 text-brand-purple" />
+                  )}
+                  <span className="text-[11px] font-semibold text-brand-purple">{note.upvotes}</span>
+                </button>
+              </div>
+
+              {/* Content preview */}
+              <p className="text-xs text-gray-500 leading-relaxed line-clamp-3">
+                {note.content}
+              </p>
+
+              {/* Footer */}
+              <div className="flex items-center justify-between text-[11px] text-gray-400 pt-1 border-t border-gray-50">
+                <span>{note.author?.full_name ?? "Unknown"} · {note.author?.office_city}</span>
+                <span>{relativeTime(note.created_at)}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/supabase/migrations/008_field_notes_jurisdiction_name.sql
+++ b/supabase/migrations/008_field_notes_jurisdiction_name.sql
@@ -1,0 +1,7 @@
+-- Migration 008: Add jurisdiction_name to field_notes
+-- The column was omitted from the initial schema but is needed for consistent
+-- display without a join to a separate lookup table. All other jurisdiction
+-- tables (matter_jurisdictions, lawyer_jurisdictions) store both code and name.
+
+ALTER TABLE field_notes
+  ADD COLUMN IF NOT EXISTS jurisdiction_name TEXT NOT NULL DEFAULT '';

--- a/types/index.ts
+++ b/types/index.ts
@@ -102,6 +102,7 @@ export interface FieldNote {
   id: string;
   author_id: string;
   jurisdiction_code: string;
+  jurisdiction_name: string;
   title: string;
   content: string;
   matter_type: string | null;


### PR DESCRIPTION
## Summary
- `GET /api/field-notes` — list firm-wide notes with `?jurisdiction=` and `?q=` filters, ordered by upvotes
- `POST /api/field-notes` — create note, awards 40 reputation points to author
- `POST /api/field-notes/[id]/upvote` — increment upvote counter, awards 10 pts to note author (atomic per-note cap via `award_upvote_points` RPC), blocks self-upvote with 400
- `/field-notes` — searchable card grid with jurisdiction filter, upvote buttons, relative timestamps
- `/field-notes/new` — contribute form with jurisdiction, title, content, matter type
- Migration 008: adds missing `jurisdiction_name` column to `field_notes` table
- `types/index.ts`: adds `jurisdiction_name` to `FieldNote` interface

## Test plan
- [ ] `/field-notes` loads all seeded notes
- [ ] Filtering by jurisdiction (e.g. CO) shows only Colombian notes
- [ ] Full-text search (`?q=FDI`) filters by title and content
- [ ] Creating a note redirects to `/field-notes` and awards 40 pts to author
- [ ] Upvoting a note increments the counter and awards 10 pts to the author
- [ ] Upvoting own note returns 400 "Cannot upvote your own note"
- [ ] 21st upvote on same note awards 0 pts (cap enforced by DB RPC)

Closes #32