### PR TITLE
fix(security): audit pass — Zod validation on lawyer PATCH, confirm all guards

### DIFF
--- a/app/api/lawyers/[id]/route.ts
+++ b/app/api/lawyers/[id]/route.ts
@@ -1,5 +1,25 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
+
+const patchLawyerSchema = z.object({
+  bio:       z.string().max(2000).optional(),
+  title:     z.string().max(100).optional(),
+  full_name: z.string().min(1).max(200).optional(),
+  languages: z.array(z.string().max(50)).max(20).optional(),
+  jurisdictions: z.array(z.object({
+    jurisdiction_code: z.string().min(2).max(10),
+    jurisdiction_name: z.string().min(1).max(100),
+    expertise_level:   z.number().int().min(1).max(5),
+    matter_types:      z.array(z.string().max(50)).max(20),
+    years_experience:  z.number().int().min(0).max(60),
+  })).max(20).optional(),
+  availability: z.array(z.object({
+    day_of_week:      z.number().int().min(0).max(6),
+    work_start_hour:  z.number().int().min(0).max(23),
+    work_end_hour:    z.number().int().min(1).max(24),
+  })).max(7).optional(),
+});
 
 export async function GET(
   _req: Request,
@@ -72,22 +92,22 @@ export async function PATCH(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  let body: {
-    bio?: string;
-    title?: string;
-    full_name?: string;
-    languages?: string[];
-    jurisdictions?: { jurisdiction_code: string; jurisdiction_name: string; expertise_level: number; matter_types: string[]; years_experience: number }[];
-    availability?: { day_of_week: number; work_start_hour: number; work_end_hour: number }[];
-  };
-
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { bio, title, full_name, languages, jurisdictions, availability } = body;
+  const parsed = patchLawyerSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const { bio, title, full_name, languages, jurisdictions, availability } = parsed.data;
 
   // Use service client — ownership already verified above
   const service = createServiceClient();


### PR DESCRIPTION
## Security Audit Findings

### ✅ Passing — no action needed

| Area | Finding |
|---|---|
| **Auth middleware** | Covers all routes. Unauthenticated requests to any non-public path redirect to `/login`. Public paths: `/`, `/login`, `/auth/...` only. |
| **API route auth** | All 14 API routes call `supabase.auth.getUser()` and return 401 before executing any logic. No unguarded routes. |
| **Service role key** | `SUPABASE_SERVICE_ROLE_KEY` only appears in `lib/supabase/server.ts` and `lib/connect/matcher.ts` — both guarded by `import "server-only"`. Never reachable from client bundles. |
| **Groq API key** | `GROQ_API_KEY` only in `lib/ai/groq.ts` — guarded by `import "server-only"`. |
| **Client Supabase** | `lib/supabase/client.ts` uses only `NEXT_PUBLIC_ANON_KEY` — correct, expected to be public. |
| **`.env.local`** | In `.gitignore` — not committed. |
| **RLS — lawyers** | SELECT: all authenticated. UPDATE: owner only (`auth.uid() = id`). |
| **RLS — matters** | SELECT: lead or matter_team member only. |
| **RLS — context_briefs** | SELECT: matter team members only. |
| **RLS — field_notes** | SELECT: firm notes to all authenticated, private to author only. UPDATE: author only. |
| **RLS — reputation_events** | SELECT: all authenticated. No INSERT policy = service role only. |
| **Server components** | `app/matters/page.tsx`, `app/matters/[id]/context/page.tsx` use `createServiceClient` but have no `"use client"` — correctly server-only. |
| **Zod coverage** | All POST routes validated. |

### 🔧 Fixed — 1 gap

**`PATCH /api/lawyers/[id]` lacked body validation** — the request body was destructured directly from `req.json()` with a TypeScript-only type annotation (no runtime check). Added a Zod schema enforcing string lengths, integer ranges, and array size limits on all fields.

## Test plan
- [ ] `PATCH /api/lawyers/[id]` with `{ bio: 12345 }` returns 400 validation error
- [ ] `PATCH /api/lawyers/[id]` with `{ bio: "valid string" }` succeeds
- [ ] Visiting `/dashboard` while logged out redirects to `/login`
- [ ] `curl /api/reputation` without a session cookie returns 401

Closes #37