### PR TITLE
Responsive padding and focus-visible states across the app (#36)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -169,7 +169,7 @@ export default async function DashboardPage() {
   ];
 
   return (
-    <div className="p-8 max-w-5xl">
+    <div className="p-4 sm:p-6 lg:p-8 max-w-5xl">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">
@@ -189,7 +189,7 @@ export default async function DashboardPage() {
           <Link
             key={label}
             href={href}
-            className="bg-white border border-brand-grey rounded-xl p-5 hover:shadow-sm transition-shadow"
+            className="bg-white border border-brand-grey rounded-xl p-5 hover:shadow-sm transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"
           >
             <div className={`w-9 h-9 rounded-lg ${bg} flex items-center justify-center mb-3`}>
               <Icon className={`w-4.5 h-4.5 ${color}`} style={{ width: 18, height: 18 }} />

--- a/app/lawyers/[id]/page.tsx
+++ b/app/lawyers/[id]/page.tsx
@@ -62,7 +62,7 @@ export default async function LawyerProfilePage({ params }: { params: { id: stri
   const events = eventsResult.data as ReputationEvent[];
 
   return (
-    <main className="flex-1 p-8 max-w-4xl">
+    <main className="flex-1 p-4 sm:p-6 lg:p-8 max-w-4xl">
       {/* Back */}
       <Link
         href="/lawyers"

--- a/app/lawyers/page.tsx
+++ b/app/lawyers/page.tsx
@@ -22,7 +22,7 @@ export default async function LawyersPage() {
 
   return (
     
-      <main className="flex-1 p-8">
+      <main className="flex-1 p-4 sm:p-6 lg:p-8">
         <LawyersDirectory lawyers={lawyers} />
       </main>
 

--- a/app/matters/[id]/_components/MatterTabs.tsx
+++ b/app/matters/[id]/_components/MatterTabs.tsx
@@ -14,7 +14,7 @@ export default function MatterTabs({ id }: { id: string }) {
   const pathname = usePathname();
 
   return (
-    <nav className="flex gap-0 -mb-px">
+    <nav className="flex gap-0 -mb-px overflow-x-auto">
       {TABS.map((tab) => {
         const href = `/matters/${id}/${tab.segment}`;
         const active = pathname === href || pathname.startsWith(href + "/");

--- a/app/matters/[id]/connect/_components/LawyerMatchCard.tsx
+++ b/app/matters/[id]/connect/_components/LawyerMatchCard.tsx
@@ -177,7 +177,8 @@ export default function LawyerMatchCard({ match, matterId, alreadyOnTeam }: Prop
         className="w-full flex items-center justify-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors
           disabled:cursor-not-allowed
           bg-brand-purple text-white hover:bg-brand-purple-dark
-          disabled:bg-gray-100 disabled:text-gray-400"
+          disabled:bg-gray-100 disabled:text-gray-400
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:ring-offset-1"
       >
         {invited ? (
           <>

--- a/app/matters/[id]/context/_components/BriefCard.tsx
+++ b/app/matters/[id]/context/_components/BriefCard.tsx
@@ -46,7 +46,7 @@ function Section({
         aria-expanded={open}
         aria-controls={sectionId}
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center justify-between w-full text-left"
+        className="flex items-center justify-between w-full text-left rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"
       >
         <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
           {label}

--- a/app/matters/[id]/flow/_components/TaskBoard.tsx
+++ b/app/matters/[id]/flow/_components/TaskBoard.tsx
@@ -61,7 +61,7 @@ export default function TaskBoard({ tasks, onRouteTask, routingTaskId }: Props) 
           >
             {/* Header row */}
             <button
-              className="w-full text-left px-4 py-3 flex items-center gap-3"
+              className="w-full text-left px-4 py-3 flex items-center gap-3 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50"
               onClick={() => setExpandedId(isExpanded ? null : task.id)}
             >
               <StatusIcon className={`w-4 h-4 flex-shrink-0 ${status.color} ${task.status === "in_progress" ? "animate-spin" : ""}`} />
@@ -101,7 +101,7 @@ export default function TaskBoard({ tasks, onRouteTask, routingTaskId }: Props) 
                     onRouteTask(task.id);
                   }}
                   disabled={isRouting}
-                  className="flex-shrink-0 text-xs font-medium px-3 py-1.5 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors"
+                  className="flex-shrink-0 text-xs font-medium px-3 py-1.5 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:ring-offset-1"
                 >
                   {isRouting ? (
                     <span className="flex items-center gap-1.5">

--- a/app/matters/[id]/flow/_components/TaskBoard.tsx
+++ b/app/matters/[id]/flow/_components/TaskBoard.tsx
@@ -59,47 +59,49 @@ export default function TaskBoard({ tasks, onRouteTask, routingTaskId }: Props) 
             key={task.id}
             className={`border rounded-xl transition-all ${status.bg} border-gray-200`}
           >
-            {/* Header row */}
-            <button
-              className="w-full text-left px-4 py-3 flex items-center gap-3 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50"
-              onClick={() => setExpandedId(isExpanded ? null : task.id)}
-            >
-              <StatusIcon className={`w-4 h-4 flex-shrink-0 ${status.color} ${task.status === "in_progress" ? "animate-spin" : ""}`} />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <p className="text-sm font-medium text-gray-900 truncate">{task.title}</p>
-                  <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full flex-shrink-0 ${priority.color}`}>
-                    {priority.label}
-                  </span>
-                </div>
-                <div className="flex items-center gap-3 mt-0.5">
-                  {task.required_jurisdiction && (
-                    <span className="text-[11px] text-brand-purple font-medium">{task.required_jurisdiction}</span>
-                  )}
-                  {task.assignee ? (
-                    <span className="text-[11px] text-gray-500 flex items-center gap-1">
-                      <User className="w-3 h-3" />
-                      {task.assignee.full_name} · {task.assignee.office_city}
+            {/* Header row — toggle and Route are siblings to avoid nested <button> */}
+            <div className="px-4 py-3 flex items-center gap-3">
+              <button
+                type="button"
+                aria-expanded={isExpanded}
+                className="flex-1 min-w-0 text-left flex items-center gap-3 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50"
+                onClick={() => setExpandedId(isExpanded ? null : task.id)}
+              >
+                <StatusIcon className={`w-4 h-4 flex-shrink-0 ${status.color} ${task.status === "in_progress" ? "animate-spin" : ""}`} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-gray-900 truncate">{task.title}</p>
+                    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full flex-shrink-0 ${priority.color}`}>
+                      {priority.label}
                     </span>
-                  ) : (
-                    <span className="text-[11px] text-gray-400">Unassigned</span>
-                  )}
-                  {task.due_date && (
-                    <span className="text-[11px] text-gray-400 flex items-center gap-1">
-                      <Clock className="w-3 h-3" />
-                      {new Date(task.due_date).toLocaleDateString()}
-                    </span>
-                  )}
+                  </div>
+                  <div className="flex items-center gap-3 mt-0.5">
+                    {task.required_jurisdiction && (
+                      <span className="text-[11px] text-brand-purple font-medium">{task.required_jurisdiction}</span>
+                    )}
+                    {task.assignee ? (
+                      <span className="text-[11px] text-gray-500 flex items-center gap-1">
+                        <User className="w-3 h-3" />
+                        {task.assignee.full_name} · {task.assignee.office_city}
+                      </span>
+                    ) : (
+                      <span className="text-[11px] text-gray-400">Unassigned</span>
+                    )}
+                    {task.due_date && (
+                      <span className="text-[11px] text-gray-400 flex items-center gap-1">
+                        <Clock className="w-3 h-3" />
+                        {new Date(task.due_date).toLocaleDateString()}
+                      </span>
+                    )}
+                  </div>
                 </div>
-              </div>
+              </button>
 
               {/* Route button — only for pending/unassigned */}
               {(task.status === "pending" || !task.assignee) && (
                 <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRouteTask(task.id);
-                  }}
+                  type="button"
+                  onClick={() => onRouteTask(task.id)}
                   disabled={isRouting}
                   className="flex-shrink-0 text-xs font-medium px-3 py-1.5 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:ring-offset-1"
                 >
@@ -113,7 +115,7 @@ export default function TaskBoard({ tasks, onRouteTask, routingTaskId }: Props) 
                   )}
                 </button>
               )}
-            </button>
+            </div>
 
             {/* Expanded detail */}
             {isExpanded && (

--- a/app/matters/[id]/layout.tsx
+++ b/app/matters/[id]/layout.tsx
@@ -38,7 +38,7 @@ export default async function MatterLayout({
   return (
     <div className="flex-1 flex flex-col min-w-0">
       {/* Matter header */}
-      <div className="bg-white border-b border-brand-grey px-8 pt-7 pb-0">
+      <div className="bg-white border-b border-brand-grey px-4 sm:px-6 lg:px-8 pt-5 sm:pt-7 pb-0">
         <Link
           href="/matters"
           className="inline-flex items-center gap-1.5 text-xs text-gray-400 hover:text-brand-purple transition-colors mb-4"
@@ -77,7 +77,7 @@ export default async function MatterLayout({
         <MatterTabs id={params.id} />
       </div>
 
-      <main className="flex-1 p-8">{children}</main>
+      <main className="flex-1 p-4 sm:p-6 lg:p-8">{children}</main>
     </div>
   );
 }

--- a/app/matters/new/page.tsx
+++ b/app/matters/new/page.tsx
@@ -9,7 +9,7 @@ export default async function NewMatterPage() {
 
   return (
     
-      <main className="flex-1 p-8 max-w-2xl">
+      <main className="flex-1 p-4 sm:p-6 lg:p-8 max-w-2xl">
         <NewMatterForm />
       </main>
 

--- a/app/matters/page.tsx
+++ b/app/matters/page.tsx
@@ -49,7 +49,7 @@ export default async function MattersPage() {
 
   return (
     
-      <main className="flex-1 p-8">
+      <main className="flex-1 p-4 sm:p-6 lg:p-8">
         <MattersDirectory matters={matters} />
       </main>
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -33,7 +33,7 @@ export default async function ProfilePage() {
 
   return (
     
-      <main className="flex-1 p-8 max-w-3xl">
+      <main className="flex-1 p-4 sm:p-6 lg:p-8 max-w-3xl">
         <ProfileForm
           lawyer={lawyer as Lawyer}
           jurisdictions={(jurisdictionsResult.data ?? []) as LawyerJurisdiction[]}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -24,7 +24,7 @@ function NavLinks({ pathname, onNav }: { pathname: string; onNav?: () => void })
             key={href}
             href={href}
             onClick={onNav}
-            className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+            className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 ${
               active
                 ? "bg-white/20 text-white"
                 : "text-white/60 hover:text-white hover:bg-white/10"
@@ -76,7 +76,7 @@ export default function Sidebar() {
         <div className="p-4 border-t border-white/10">
           <button
             onClick={handleSignOut}
-            className="flex items-center gap-3 px-3 py-2 w-full rounded-lg text-sm font-medium text-white/60 hover:text-white hover:bg-white/10 transition-colors"
+            className="flex items-center gap-3 px-3 py-2 w-full rounded-lg text-sm font-medium text-white/60 hover:text-white hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
           >
             <LogOut className="w-4 h-4 flex-shrink-0" />
             Sign out
@@ -88,12 +88,12 @@ export default function Sidebar() {
       <div className="lg:hidden fixed top-0 left-0 right-0 z-40 bg-brand-purple flex items-center justify-between px-4 h-14 border-b border-white/10">
         <Logo />
         <div className="flex items-center gap-2">
-          <Link href="/profile" className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center hover:bg-white/30 transition-colors">
+          <Link href="/profile" className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center hover:bg-white/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60">
             <span className="text-white text-xs font-semibold">Me</span>
           </Link>
           <button
             onClick={() => setMobileOpen(true)}
-            className="text-white/70 hover:text-white p-1"
+            className="text-white/70 hover:text-white p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
             aria-label="Open navigation"
           >
             <Menu className="w-5 h-5" />
@@ -115,7 +115,7 @@ export default function Sidebar() {
               <Logo />
               <button
                 onClick={() => setMobileOpen(false)}
-                className="text-white/70 hover:text-white p-1"
+                className="text-white/70 hover:text-white p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
                 aria-label="Close navigation"
               >
                 <X className="w-5 h-5" />
@@ -127,7 +127,7 @@ export default function Sidebar() {
             <div className="p-4 border-t border-white/10">
               <button
                 onClick={handleSignOut}
-                className="flex items-center gap-3 px-3 py-2 w-full rounded-lg text-sm font-medium text-white/60 hover:text-white hover:bg-white/10 transition-colors"
+                className="flex items-center gap-3 px-3 py-2 w-full rounded-lg text-sm font-medium text-white/60 hover:text-white hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
               >
                 <LogOut className="w-4 h-4 flex-shrink-0" />
                 Sign out

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -41,6 +41,7 @@ export default function TopBar() {
     <div className="h-14 flex items-center justify-end px-6 border-b border-gray-100 bg-white flex-shrink-0">
       <Link
         href="/profile"
+        aria-label="My profile"
         className="flex items-center gap-2.5 group rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50"
         title="My profile"
       >

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -41,7 +41,7 @@ export default function TopBar() {
     <div className="h-14 flex items-center justify-end px-6 border-b border-gray-100 bg-white flex-shrink-0">
       <Link
         href="/profile"
-        className="flex items-center gap-2.5 group"
+        className="flex items-center gap-2.5 group rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50"
         title="My profile"
       >
         <span className="text-sm text-gray-500 group-hover:text-gray-700 transition-colors hidden sm:block">


### PR DESCRIPTION
## Summary
- `app/dashboard/page.tsx`, `app/matters/page.tsx`, `app/matters/new/page.tsx`, `app/matters/[id]/layout.tsx`, `app/lawyers/page.tsx`, `app/lawyers/[id]/page.tsx`, `app/profile/page.tsx`: `p-8` → `p-4 sm:p-6 lg:p-8` so mobile gets 16px padding instead of 32px
- `app/matters/[id]/_components/MatterTabs.tsx`: `overflow-x-auto` on tab nav so 4 tabs scroll on narrow screens instead of overflowing
- `components/layout/Sidebar.tsx`, `components/layout/TopBar.tsx`, `app/matters/[id]/flow/_components/TaskBoard.tsx`, `app/matters/[id]/connect/_components/LawyerMatchCard.tsx`, `app/matters/[id]/context/_components/BriefCard.tsx`, `app/dashboard/page.tsx`: added `focus-visible:ring-*` classes to all primary interactive elements (nav links, sign-out, hamburger, close, profile link, stat cards, Route button, Invite button, section toggles)

## Test plan
- [x] DevTools at 375px (iPhone SE) and 768px (iPad) — no horizontal scroll, all content fits
- [x] Tab key walks through sidebar → TopBar → page content with a visible ring at every stop
- [x] `npx tsc --noEmit` clean

Closes #36