### PR TITLE
Fix RLS recursion on Flow task creation

### DIFF
--- a/app/api/flow/route-task/route.ts
+++ b/app/api/flow/route-task/route.ts
@@ -16,7 +16,12 @@ export async function POST(request: Request) {
   } = await supabase.auth.getUser();
   if (!user?.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });

--- a/app/api/flow/route-task/route.ts
+++ b/app/api/flow/route-task/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { routeTask } from "@/lib/flow/engine";
 import { z } from "zod";
@@ -11,14 +11,40 @@ const schema = z.object({
 // Runs the Flow engine on a single task — assigns it to the best available lawyer
 export async function POST(request: Request) {
   const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await request.json();
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   }
+
+  // Verify caller is on the task's matter team
+  const service = createServiceClient();
+  const { data: lawyer } = await service
+    .from("lawyers")
+    .select("id")
+    .eq("email", user.email)
+    .maybeSingle();
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: task } = await service
+    .from("tasks")
+    .select("matter_id")
+    .eq("id", parsed.data.task_id)
+    .maybeSingle();
+  if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+
+  const { data: membership } = await service
+    .from("matter_team")
+    .select("role")
+    .eq("matter_id", task.matter_id)
+    .eq("lawyer_id", lawyer.id)
+    .maybeSingle();
+  if (!membership) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   try {
     const result = await routeTask(parsed.data.task_id);

--- a/app/api/flow/tasks/[id]/route.ts
+++ b/app/api/flow/tasks/[id]/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -12,14 +12,47 @@ const updateTaskSchema = z.object({
   handoff_context: z.string().nullable().optional(),
 });
 
+async function getAuthenticatedLawyer() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return null;
+
+  const service = createServiceClient();
+  const { data: lawyer } = await service
+    .from("lawyers")
+    .select("id, email")
+    .eq("email", user.email)
+    .maybeSingle();
+  return lawyer;
+}
+
+async function getTaskIfOnTeam(taskId: string, lawyerId: string) {
+  const service = createServiceClient();
+  const { data: task } = await service
+    .from("tasks")
+    .select("id, matter_id")
+    .eq("id", taskId)
+    .maybeSingle();
+  if (!task) return null;
+
+  const { data: membership } = await service
+    .from("matter_team")
+    .select("role")
+    .eq("matter_id", task.matter_id)
+    .eq("lawyer_id", lawyerId)
+    .maybeSingle();
+  return membership ? task : null;
+}
+
 // PATCH /api/flow/tasks/[id]
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await request.json();
   const parsed = updateTaskSchema.safeParse(body);
@@ -27,7 +60,12 @@ export async function PATCH(
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   }
 
-  const { data, error } = await supabase
+  if (!(await getTaskIfOnTeam(params.id, lawyer.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const service = createServiceClient();
+  const { data, error } = await service
     .from("tasks")
     .update(parsed.data)
     .eq("id", params.id)
@@ -43,11 +81,15 @@ export async function GET(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { data, error } = await supabase
+  if (!(await getTaskIfOnTeam(params.id, lawyer.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const service = createServiceClient();
+  const { data, error } = await service
     .from("tasks")
     .select(`
       *,

--- a/app/api/flow/tasks/[id]/route.ts
+++ b/app/api/flow/tasks/[id]/route.ts
@@ -54,10 +54,18 @@ export async function PATCH(
   const lawyer = await getAuthenticatedLawyer();
   if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
   const parsed = updateTaskSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  if (Object.keys(parsed.data).length === 0) {
+    return NextResponse.json({ error: "No fields to update" }, { status: 400 });
   }
 
   if (!(await getTaskIfOnTeam(params.id, lawyer.id))) {

--- a/app/api/flow/tasks/route.ts
+++ b/app/api/flow/tasks/route.ts
@@ -2,6 +2,8 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const createTaskSchema = z.object({
   matter_id: z.string().uuid(),
   title: z.string().min(1),
@@ -49,6 +51,9 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const matterId = searchParams.get("matter_id");
   if (!matterId) return NextResponse.json({ error: "matter_id required" }, { status: 400 });
+  if (!UUID_RE.test(matterId)) {
+    return NextResponse.json({ error: "matter_id must be a UUID" }, { status: 400 });
+  }
 
   if (!(await isOnTeam(matterId, lawyer.id))) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
@@ -78,7 +83,12 @@ export async function POST(request: Request) {
   const lawyer = await getAuthenticatedLawyer();
   if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
   const parsed = createTaskSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });

--- a/app/api/flow/tasks/route.ts
+++ b/app/api/flow/tasks/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -12,17 +12,50 @@ const createTaskSchema = z.object({
   due_date: z.string().optional().nullable(),
 });
 
+async function getAuthenticatedLawyer() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return null;
+
+  const service = createServiceClient();
+  const { data: lawyer, error } = await service
+    .from("lawyers")
+    .select("id, email")
+    .eq("email", user.email)
+    .maybeSingle();
+
+  if (error) return null;
+  return lawyer;
+}
+
+async function isOnTeam(matterId: string, lawyerId: string) {
+  const service = createServiceClient();
+  const { data } = await service
+    .from("matter_team")
+    .select("role")
+    .eq("matter_id", matterId)
+    .eq("lawyer_id", lawyerId)
+    .maybeSingle();
+  return !!data;
+}
+
 // GET /api/flow/tasks?matter_id=xxx
 export async function GET(request: Request) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { searchParams } = new URL(request.url);
   const matterId = searchParams.get("matter_id");
   if (!matterId) return NextResponse.json({ error: "matter_id required" }, { status: 400 });
 
-  const { data, error } = await supabase
+  if (!(await isOnTeam(matterId, lawyer.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const service = createServiceClient();
+  const { data, error } = await service
     .from("tasks")
     .select(`
       *,
@@ -42,9 +75,8 @@ export async function GET(request: Request) {
 
 // POST /api/flow/tasks
 export async function POST(request: Request) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await request.json();
   const parsed = createTaskSchema.safeParse(body);
@@ -52,7 +84,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   }
 
-  const { data, error } = await supabase
+  if (!(await isOnTeam(parsed.data.matter_id, lawyer.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const service = createServiceClient();
+  const { data, error } = await service
     .from("tasks")
     .insert(parsed.data)
     .select()


### PR DESCRIPTION
## Summary
Fixes `{ "error": "infinite recursion detected in policy for relation \"matter_team\"" }` hit during task creation on the Flow tab.

**Root cause:** `app/api/flow/tasks/route.ts`, `app/api/flow/tasks/[id]/route.ts`, and `app/api/flow/route-task/route.ts` were using the regular Supabase client (subject to RLS). The `tasks` table's SELECT policy references `matter_team`, whose SELECT policy references `matters`, whose SELECT policy references `matter_team` — Postgres detected the cycle and aborted the query.

**Fix:** switch all three routes to `createServiceClient()` (bypasses RLS) and add explicit team-membership guards, matching the pattern used by the other API routes in the app (`/api/matters`, `/api/connect/match`, `/api/matters/[id]/team`). This is the right fix regardless of the RLS bug — seeded lawyer IDs don't match Supabase Auth UIDs, so the RLS policies were effectively broken for seeded users anyway.

## Changes
- `app/api/flow/tasks/route.ts`: GET + POST now auth → team-check → service-client query
- `app/api/flow/tasks/[id]/route.ts`: GET + PATCH now auth → team-check → service-client query
- `app/api/flow/route-task/route.ts`: added missing team-membership guard (previously any authenticated user could route any task)

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Create a task from the Flow tab — no recursion error
- [ ] GET + PATCH on an existing task work end-to-end
- [ ] Non-team-member requests return 403