### PR TITLE
fix(#71): prevent button text wrapping in Flow tab and Profile tab

### DIFF
--- a/app/matters/[id]/flow/_components/TaskBoard.tsx
+++ b/app/matters/[id]/flow/_components/TaskBoard.tsx
@@ -103,7 +103,7 @@ export default function TaskBoard({ tasks, onRouteTask, routingTaskId }: Props) 
                   type="button"
                   onClick={() => onRouteTask(task.id)}
                   disabled={isRouting}
-                  className="flex-shrink-0 text-xs font-medium px-3 py-1.5 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:ring-offset-1"
+                  className="flex-shrink-0 text-xs font-medium px-3 py-1.5 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50 focus-visible:ring-offset-1"
                 >
                   {isRouting ? (
                     <span className="flex items-center gap-1.5">

--- a/app/matters/[id]/flow/page.tsx
+++ b/app/matters/[id]/flow/page.tsx
@@ -165,33 +165,33 @@ export default function FlowPage() {
       )}
 
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <h2 className="text-lg font-semibold text-gray-900">Task Flow</h2>
           <p className="text-sm text-gray-500 mt-0.5">
             Route work across timezones — tasks are assigned to available lawyers automatically
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-shrink-0">
           {unroutedCount > 0 && (
             <button
               onClick={handleRouteAll}
               disabled={routingAll}
-              className="flex items-center gap-2 text-sm font-medium px-4 py-2 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors"
+              className="flex items-center gap-2 text-sm font-medium px-4 py-2 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors whitespace-nowrap"
             >
               {routingAll ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
+                <Loader2 className="w-4 h-4 animate-spin flex-shrink-0" />
               ) : (
-                <Zap className="w-4 h-4" />
+                <Zap className="w-4 h-4 flex-shrink-0" />
               )}
               Route All ({unroutedCount})
             </button>
           )}
           <button
             onClick={() => setShowForm((v) => !v)}
-            className="flex items-center gap-2 text-sm font-medium px-4 py-2 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 text-sm font-medium px-4 py-2 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap"
           >
-            <Plus className="w-4 h-4" />
+            <Plus className="w-4 h-4 flex-shrink-0" />
             Add Task
           </button>
         </div>

--- a/app/matters/[id]/flow/page.tsx
+++ b/app/matters/[id]/flow/page.tsx
@@ -172,7 +172,7 @@ export default function FlowPage() {
             Route work across timezones — tasks are assigned to available lawyers automatically
           </p>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 flex-wrap">
           {unroutedCount > 0 && (
             <button
               onClick={handleRouteAll}

--- a/app/profile/_components/ProfileForm.tsx
+++ b/app/profile/_components/ProfileForm.tsx
@@ -155,7 +155,7 @@ export default function ProfileForm({ lawyer, jurisdictions: initialJur, availab
           <h1 className="text-2xl font-bold text-gray-900">My Profile</h1>
           <p className="text-sm text-gray-500 mt-1">Keep your expertise up to date to improve match quality</p>
         </div>
-        <div className="flex items-center gap-3 flex-shrink-0">
+        <div className="flex items-center gap-3 flex-wrap">
           {saved && (
             <span className="flex items-center gap-1.5 text-sm text-green-600 font-medium whitespace-nowrap">
               <Check className="w-4 h-4 flex-shrink-0" /> Profile updated

--- a/app/profile/_components/ProfileForm.tsx
+++ b/app/profile/_components/ProfileForm.tsx
@@ -150,21 +150,21 @@ export default function ProfileForm({ lawyer, jurisdictions: initialJur, availab
   return (
     <div>
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-start justify-between gap-4 flex-wrap mb-6">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">My Profile</h1>
           <p className="text-sm text-gray-500 mt-1">Keep your expertise up to date to improve match quality</p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-shrink-0">
           {saved && (
-            <span className="flex items-center gap-1.5 text-sm text-green-600 font-medium">
-              <Check className="w-4 h-4" /> Profile updated
+            <span className="flex items-center gap-1.5 text-sm text-green-600 font-medium whitespace-nowrap">
+              <Check className="w-4 h-4 flex-shrink-0" /> Profile updated
             </span>
           )}
           <button
             onClick={handleSave}
             disabled={saving}
-            className="px-4 py-2 bg-brand-purple text-white text-sm font-medium rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="px-4 py-2 bg-brand-purple text-white text-sm font-medium rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
           >
             {saving ? "Saving..." : "Save changes"}
           </button>


### PR DESCRIPTION
## Summary

- Added `whitespace-nowrap` to Route All, Add Task (Flow tab) and Save Changes (Profile tab) buttons
- Changed header flex containers to `flex-wrap` with `flex-shrink-0` on button groups so they reflow onto a new line before text ever wraps
- Added `flex-shrink-0` to icons inside buttons

## Test plan
- [ ] Visit `/matters/[id]/flow` at ~900px viewport — Route All and Add Task buttons stay single line
- [ ] Visit `/profile` at ~900px viewport — Save Changes button stays single line
- [ ] At very narrow widths, button group wraps below the heading (not the button text itself)

Closes #71