### PR TITLE
fix: team invite accept/decline flow with bell notifications (#73)

### DIFF
--- a/app/api/matters/[id]/team/route.ts
+++ b/app/api/matters/[id]/team/route.ts
@@ -5,9 +5,10 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 const addMemberSchema = z.object({
   lawyer_id: z.string().uuid(),
   role: z.enum(["collaborator", "reviewer"]).default("collaborator"),
-  // match_score is intentionally excluded from the client payload —
-  // trusting the client to supply it would allow arbitrary score injection.
-  // The score is stored as null here; issue #25 will populate it server-side.
+});
+
+const respondSchema = z.object({
+  action: z.enum(["accept", "decline"]),
 });
 
 const INVITER_POINTS = 20;
@@ -42,7 +43,6 @@ export async function GET(
 
   const service = createServiceClient();
 
-  // Verify membership — 403 (not 404) so callers know the matter exists but they lack access
   const { data: membership } = await service
     .from("matter_team")
     .select("role")
@@ -57,7 +57,7 @@ export async function GET(
   const { data: team, error } = await service
     .from("matter_team")
     .select(
-      "id, role, match_score, joined_at, lawyer:lawyers(id, full_name, title, office_city, timezone, reputation_score)"
+      "id, role, status, match_score, joined_at, lawyer:lawyers(id, full_name, title, office_city, timezone, reputation_score)"
     )
     .eq("matter_id", params.id)
     .order("joined_at");
@@ -95,7 +95,6 @@ export async function POST(
 
   const { lawyer_id, role } = parsed.data;
 
-  // Cannot invite yourself
   if (lawyer_id === lawyer.id) {
     return NextResponse.json(
       { error: "Cannot invite yourself to a matter" },
@@ -105,7 +104,6 @@ export async function POST(
 
   const service = createServiceClient();
 
-  // Verify current user is on the team
   const { data: membership } = await service
     .from("matter_team")
     .select("role")
@@ -117,7 +115,6 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Verify invited lawyer exists
   const { data: invitee, error: inviteeError } = await service
     .from("lawyers")
     .select("id, reputation_score")
@@ -128,78 +125,134 @@ export async function POST(
     return NextResponse.json({ error: "Lawyer not found" }, { status: 404 });
   }
 
-  // Check for duplicate
   const { data: existing } = await service
     .from("matter_team")
-    .select("id")
+    .select("id, status")
     .eq("matter_id", params.id)
     .eq("lawyer_id", lawyer_id)
     .maybeSingle();
 
   if (existing) {
     return NextResponse.json(
-      { error: "Lawyer is already on this matter's team" },
+      { error: "Lawyer has already been invited to this matter" },
       { status: 409 }
     );
   }
 
-  // Add to team (match_score stored as null — populated server-side in issue #25)
+  // Create invite as pending — reputation awarded only on acceptance
   const { data: newMember, error: insertError } = await service
     .from("matter_team")
-    .insert({ matter_id: params.id, lawyer_id, role, match_score: null })
-    .select("id, matter_id, lawyer_id, role, match_score, joined_at")
+    .insert({ matter_id: params.id, lawyer_id, role, match_score: null, status: "pending" })
+    .select("id, matter_id, lawyer_id, role, status, match_score, joined_at")
     .single();
 
   if (insertError || !newMember) {
     return NextResponse.json({ error: "Failed to add team member" }, { status: 500 });
   }
 
-  // Fetch inviter's current score for the increment
-  const { data: inviter, error: inviterError } = await service
+  // Award the inviter's points immediately for sending the invite
+  const { data: inviter } = await service
     .from("lawyers")
     .select("reputation_score")
     .eq("id", lawyer.id)
     .single();
 
-  if (inviterError || !inviter) {
-    // Team member was added — log and continue rather than failing the request
-    console.error("Failed to fetch inviter reputation score:", inviterError?.message);
-    return NextResponse.json(newMember, { status: 201 });
-  }
-
-  // Award reputation — fail fast with Promise.all so errors surface
-  const [evInviter, evInvitee, repInviter, repInvitee] = await Promise.all([
-    service.from("reputation_events").insert({
-      lawyer_id: lawyer.id,
-      event_type: "match_accepted",
-      points: INVITER_POINTS,
-      matter_id: params.id,
-      description: "Invited a lawyer to the matter team",
-    }),
-    service.from("reputation_events").insert({
-      lawyer_id,
-      event_type: "matter_joined",
-      points: INVITEE_POINTS,
-      matter_id: params.id,
-      description: "Joined matter team",
-    }),
-    service
-      .from("lawyers")
-      .update({ reputation_score: inviter.reputation_score + INVITER_POINTS })
-      .eq("id", lawyer.id),
-    service
-      .from("lawyers")
-      .update({ reputation_score: invitee.reputation_score + INVITEE_POINTS })
-      .eq("id", lawyer_id),
-  ]);
-
-  // Log any reputation errors — team membership is already committed
-  const repErrors = [evInviter, evInvitee, repInviter, repInvitee]
-    .map((r) => r.error)
-    .filter(Boolean);
-  if (repErrors.length > 0) {
-    console.error("Reputation award errors:", repErrors.map((e) => e!.message));
+  if (inviter) {
+    await Promise.all([
+      service.from("reputation_events").insert({
+        lawyer_id: lawyer.id,
+        event_type: "match_accepted",
+        points: INVITER_POINTS,
+        matter_id: params.id,
+        description: "Invited a lawyer to the matter team",
+      }),
+      service
+        .from("lawyers")
+        .update({ reputation_score: inviter.reputation_score + INVITER_POINTS })
+        .eq("id", lawyer.id),
+    ]);
   }
 
   return NextResponse.json(newMember, { status: 201 });
+}
+
+// Accept or decline a pending invite for the current user
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = respondSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const { action } = parsed.data;
+  const service = createServiceClient();
+
+  // Find the pending invite for this lawyer on this matter
+  const { data: invite } = await service
+    .from("matter_team")
+    .select("id, lawyer_id")
+    .eq("matter_id", params.id)
+    .eq("lawyer_id", lawyer.id)
+    .eq("status", "pending")
+    .maybeSingle();
+
+  if (!invite) {
+    return NextResponse.json({ error: "No pending invite found" }, { status: 404 });
+  }
+
+  if (action === "decline") {
+    await service.from("matter_team").delete().eq("id", invite.id);
+    return NextResponse.json({ status: "declined" });
+  }
+
+  // Accept: flip status and award invitee reputation
+  const { error: updateError } = await service
+    .from("matter_team")
+    .update({ status: "accepted" })
+    .eq("id", invite.id);
+
+  if (updateError) {
+    return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 });
+  }
+
+  const { data: invitee } = await service
+    .from("lawyers")
+    .select("reputation_score")
+    .eq("id", lawyer.id)
+    .single();
+
+  if (invitee) {
+    await Promise.all([
+      service.from("reputation_events").insert({
+        lawyer_id: lawyer.id,
+        event_type: "matter_joined",
+        points: INVITEE_POINTS,
+        matter_id: params.id,
+        description: "Joined matter team",
+      }),
+      service
+        .from("lawyers")
+        .update({ reputation_score: invitee.reputation_score + INVITEE_POINTS })
+        .eq("id", lawyer.id),
+    ]);
+  }
+
+  return NextResponse.json({ status: "accepted" });
 }

--- a/app/api/matters/[id]/team/route.ts
+++ b/app/api/matters/[id]/team/route.ts
@@ -109,6 +109,7 @@ export async function POST(
     .select("role")
     .eq("matter_id", params.id)
     .eq("lawyer_id", lawyer.id)
+    .eq("status", "accepted")
     .maybeSingle();
 
   if (!membership) {
@@ -218,7 +219,13 @@ export async function PATCH(
   }
 
   if (action === "decline") {
-    await service.from("matter_team").delete().eq("id", invite.id);
+    const { error: deleteError } = await service
+      .from("matter_team")
+      .delete()
+      .eq("id", invite.id);
+    if (deleteError) {
+      return NextResponse.json({ error: "Failed to decline invite" }, { status: 500 });
+    }
     return NextResponse.json({ status: "declined" });
   }
 

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+
+export interface PendingInvite {
+  type: "invite";
+  id: string; // matter_team.id
+  matter_id: string;
+  matter_title: string;
+  role: string;
+  invited_at: string;
+}
+
+export interface ActivityEvent {
+  type: "event";
+  id: string;
+  event_type: string;
+  points: number;
+  description: string;
+  matter_id: string | null;
+  matter_title: string | null;
+  created_at: string;
+}
+
+export type NotificationItem = PendingInvite | ActivityEvent;
+
+export async function GET() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const service = createServiceClient();
+
+  const { data: lawyer } = await service
+    .from("lawyers")
+    .select("id")
+    .eq("email", user.email)
+    .maybeSingle();
+
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // Pending invites for this lawyer
+  const { data: inviteRows } = await service
+    .from("matter_team")
+    .select("id, matter_id, role, joined_at, matters(title)")
+    .eq("lawyer_id", lawyer.id)
+    .eq("status", "pending")
+    .order("joined_at", { ascending: false });
+
+  const invites: PendingInvite[] = (inviteRows ?? []).map((row) => ({
+    type: "invite" as const,
+    id: row.id,
+    matter_id: row.matter_id,
+    matter_title: (row.matters as unknown as { title: string } | null)?.title ?? "Unknown matter",
+    role: row.role,
+    invited_at: row.joined_at,
+  }));
+
+  // Past reputation events
+  const { data: eventRows } = await service
+    .from("reputation_events")
+    .select("id, event_type, points, description, matter_id, created_at, matters(title)")
+    .eq("lawyer_id", lawyer.id)
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  const events: ActivityEvent[] = (eventRows ?? []).map((row) => ({
+    type: "event" as const,
+    id: row.id,
+    event_type: row.event_type,
+    points: row.points,
+    description: row.description,
+    matter_id: row.matter_id ?? null,
+    matter_title: (row.matters as unknown as { title: string } | null)?.title ?? null,
+    created_at: row.created_at,
+  }));
+
+  return NextResponse.json({ invites, events });
+}

--- a/app/matters/[id]/_lib/getMatter.ts
+++ b/app/matters/[id]/_lib/getMatter.ts
@@ -18,6 +18,7 @@ export type MatterDetail = {
   matter_team: {
     id: string;
     role: "lead" | "collaborator" | "reviewer";
+    status: "pending" | "accepted" | "declined";
     match_score: number | null;
     joined_at: string;
     lawyer: {
@@ -72,7 +73,7 @@ export const getMatterDetail = cache(async (id: string): Promise<MatterDetail | 
       id, title, description, client_name, matter_type, status, deadline, created_at,
       matter_jurisdictions(id, jurisdiction_code, jurisdiction_name),
       matter_team(
-        id, role, match_score, joined_at,
+        id, role, status, match_score, joined_at,
         lawyer:lawyers(id, full_name, title, office_city, office_country, reputation_score, avatar_url)
       ),
       context_briefs(id, jurisdiction_code, jurisdiction_name, status)

--- a/app/matters/[id]/connect/_components/LawyerMatchCard.tsx
+++ b/app/matters/[id]/connect/_components/LawyerMatchCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Check, Star } from "lucide-react";
 import { JURISDICTIONS } from "@/lib/jurisdictions";
 import type { EnrichedMatch } from "@/app/api/connect/match/route";
@@ -81,6 +82,7 @@ type Props = {
 };
 
 export default function LawyerMatchCard({ match, matterId, alreadyOnTeam }: Props) {
+  const router = useRouter();
   const [invited, setInvited] = useState(alreadyOnTeam);
   const [inviting, setInviting] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -97,6 +99,7 @@ export default function LawyerMatchCard({ match, matterId, alreadyOnTeam }: Prop
         setInvited(true);
         setToast("+20 reputation points");
         setTimeout(() => setToast(null), 3000);
+        router.refresh();
       }
     } finally {
       setInviting(false);

--- a/app/matters/[id]/overview/page.tsx
+++ b/app/matters/[id]/overview/page.tsx
@@ -59,13 +59,19 @@ function TeamMemberCard({ member }: { member: TeamMember }) {
       </div>
 
       <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
-        <span
-          className={`text-[11px] font-medium px-2 py-0.5 rounded-full border ${
-            ROLE_STYLES[member.role] ?? ROLE_STYLES.collaborator
-          }`}
-        >
-          {member.role.charAt(0).toUpperCase() + member.role.slice(1)}
-        </span>
+        {member.status === "pending" ? (
+          <span className="text-[11px] font-medium px-2 py-0.5 rounded-full border bg-gray-100 text-gray-500 border-gray-200">
+            Pending
+          </span>
+        ) : (
+          <span
+            className={`text-[11px] font-medium px-2 py-0.5 rounded-full border ${
+              ROLE_STYLES[member.role] ?? ROLE_STYLES.collaborator
+            }`}
+          >
+            {member.role.charAt(0).toUpperCase() + member.role.slice(1)}
+          </span>
+        )}
         <span className="text-[11px] text-gray-400">
           {lawyer.reputation_score.toLocaleString()} pts
         </span>

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { Bell, Loader2 } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
+import type { PendingInvite, ActivityEvent } from "@/app/api/notifications/route";
+
+const STORAGE_KEY = "bell_last_seen";
 
 function getInitials(name: string) {
   const parts = name.trim().split(" ");
@@ -12,22 +16,87 @@ function getInitials(name: string) {
     : name[0].toUpperCase();
 }
 
+function relativeTime(date: string): string {
+  const diff = Date.now() - new Date(date).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function InviteRow({
+  invite,
+  onRespond,
+}: {
+  invite: PendingInvite;
+  onRespond: (id: string, action: "accept" | "decline") => Promise<void>;
+}) {
+  const [loading, setLoading] = useState<"accept" | "decline" | null>(null);
+
+  async function handle(action: "accept" | "decline") {
+    setLoading(action);
+    await onRespond(invite.matter_id, action);
+    setLoading(null);
+  }
+
+  return (
+    <div className="px-4 py-3 bg-brand-purple/5 border-b border-gray-100">
+      <p className="text-xs font-medium text-gray-800 leading-relaxed">
+        You've been invited to{" "}
+        <span className="text-brand-purple">{invite.matter_title}</span>
+      </p>
+      <p className="text-[11px] text-gray-400 mt-0.5 mb-2">
+        as {invite.role} · {relativeTime(invite.invited_at)}
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void handle("accept")}
+          disabled={loading !== null}
+          className="flex items-center gap-1 text-[11px] font-semibold px-3 py-1 bg-brand-purple text-white rounded-lg hover:bg-brand-purple-dark disabled:opacity-50 transition-colors"
+        >
+          {loading === "accept" && <Loader2 className="w-2.5 h-2.5 animate-spin" />}
+          Accept
+        </button>
+        <button
+          type="button"
+          onClick={() => void handle("decline")}
+          disabled={loading !== null}
+          className="flex items-center gap-1 text-[11px] font-medium px-3 py-1 border border-gray-200 text-gray-500 rounded-lg hover:bg-gray-100 disabled:opacity-50 transition-colors"
+        >
+          {loading === "decline" && <Loader2 className="w-2.5 h-2.5 animate-spin" />}
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function TopBar() {
   const [name, setName] = useState<string | null>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [invites, setInvites] = useState<PendingInvite[]>([]);
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [bellOpen, setBellOpen] = useState(false);
+  const [lastSeen, setLastSeen] = useState<number>(0);
+  const bellRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) setLastSeen(parseInt(stored, 10));
+  }, []);
 
   useEffect(() => {
     const supabase = createClient();
-
     supabase.auth.getUser().then(async ({ data: { user } }) => {
       if (!user) return;
-
       const { data } = await supabase
         .from("lawyers")
         .select("full_name, avatar_url")
         .eq("email", user.email)
         .single();
-
       if (data) {
         setName(data.full_name);
         setAvatarUrl(data.avatar_url ?? null);
@@ -35,10 +104,138 @@ export default function TopBar() {
     });
   }, []);
 
+  const fetchNotifications = useCallback(async () => {
+    const res = await fetch("/api/notifications");
+    if (res.ok) {
+      const data = await res.json();
+      setInvites(data.invites ?? []);
+      setEvents(data.events ?? []);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchNotifications();
+  }, [fetchNotifications]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (bellRef.current && !bellRef.current.contains(e.target as Node)) {
+        setBellOpen(false);
+      }
+    }
+    if (bellOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [bellOpen]);
+
+  const newEventsCount = events.filter(
+    (e) => new Date(e.created_at).getTime() > lastSeen
+  ).length;
+  const unreadCount = invites.length + newEventsCount;
+
+  function handleBellClick() {
+    if (!bellOpen) {
+      const now = Date.now();
+      setLastSeen(now);
+      localStorage.setItem(STORAGE_KEY, String(now));
+    }
+    setBellOpen((v) => !v);
+  }
+
+  async function handleRespond(matterId: string, action: "accept" | "decline") {
+    const res = await fetch(`/api/matters/${matterId}/team`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action }),
+    });
+    if (res.ok) {
+      // Remove invite from list and re-fetch events to pick up new rep event on accept
+      setInvites((prev) => prev.filter((i) => i.matter_id !== matterId));
+      if (action === "accept") await fetchNotifications();
+    }
+  }
+
   if (!name) return null;
 
+  const hasContent = invites.length > 0 || events.length > 0;
+
   return (
-    <div className="h-14 flex items-center justify-end px-6 border-b border-gray-100 bg-white flex-shrink-0">
+    <div className="h-14 flex items-center justify-end gap-3 px-6 border-b border-gray-100 bg-white flex-shrink-0">
+      {/* Bell */}
+      <div className="relative" ref={bellRef}>
+        <button
+          type="button"
+          onClick={handleBellClick}
+          className="relative p-2 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50"
+          aria-label="Notifications"
+        >
+          <Bell className="w-4 h-4" />
+          {unreadCount > 0 && (
+            <span className="absolute top-1 right-1 w-4 h-4 bg-red-500 text-white text-[9px] font-bold rounded-full flex items-center justify-center">
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          )}
+        </button>
+
+        {bellOpen && (
+          <div className="absolute right-0 top-full mt-1 w-80 bg-white border border-gray-200 rounded-xl shadow-lg z-50 overflow-hidden">
+            <div className="px-4 py-3 border-b border-gray-100">
+              <p className="text-xs font-semibold text-gray-700">Notifications</p>
+            </div>
+
+            {!hasContent && (
+              <div className="px-4 py-8 text-center">
+                <p className="text-xs text-gray-400">No activity yet</p>
+              </div>
+            )}
+
+            {/* Pending invites */}
+            {invites.map((invite) => (
+              <InviteRow key={invite.id} invite={invite} onRespond={handleRespond} />
+            ))}
+
+            {/* Past activity */}
+            {events.length > 0 && (
+              <div className="divide-y divide-gray-50 max-h-64 overflow-y-auto">
+                {events.map((e) => (
+                  <div key={e.id} className="px-4 py-3 hover:bg-gray-50 transition-colors">
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-xs text-gray-700 leading-relaxed">{e.description}</p>
+                      <span className="text-[11px] font-semibold text-green-600 flex-shrink-0">
+                        +{e.points}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5 mt-1">
+                      {e.matter_title && (
+                        <span className="text-[11px] text-brand-purple truncate max-w-[160px]">
+                          {e.matter_title}
+                        </span>
+                      )}
+                      {e.matter_title && (
+                        <span className="text-[11px] text-gray-300">·</span>
+                      )}
+                      <span className="text-[11px] text-gray-400">{relativeTime(e.created_at)}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="px-4 py-2.5 border-t border-gray-100">
+              <Link
+                href="/reputation"
+                onClick={() => setBellOpen(false)}
+                className="text-xs text-brand-purple font-medium hover:underline"
+              >
+                View full history →
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Profile */}
       <Link
         href="/profile"
         aria-label="My profile"

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -31,14 +31,17 @@ function InviteRow({
   onRespond,
 }: {
   invite: PendingInvite;
-  onRespond: (id: string, action: "accept" | "decline") => Promise<void>;
+  onRespond: (matterId: string, action: "accept" | "decline") => Promise<void>;
 }) {
   const [loading, setLoading] = useState<"accept" | "decline" | null>(null);
 
   async function handle(action: "accept" | "decline") {
     setLoading(action);
-    await onRespond(invite.matter_id, action);
-    setLoading(null);
+    try {
+      await onRespond(invite.matter_id, action);
+    } finally {
+      setLoading(null);
+    }
   }
 
   return (
@@ -85,7 +88,10 @@ export default function TopBar() {
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) setLastSeen(parseInt(stored, 10));
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (Number.isFinite(parsed)) setLastSeen(parsed);
+    }
   }, []);
 
   useEffect(() => {

--- a/supabase/migrations/009_team_invite_status.sql
+++ b/supabase/migrations/009_team_invite_status.sql
@@ -1,0 +1,5 @@
+-- Add invite status to matter_team
+-- Existing rows default to 'accepted' since they were added before this flow existed
+ALTER TABLE matter_team
+  ADD COLUMN status TEXT NOT NULL DEFAULT 'accepted'
+    CHECK (status IN ('pending', 'accepted', 'declined'));


### PR DESCRIPTION
## Summary
- Adds `status` column (`pending/accepted/declined`) to `matter_team` via migration 009
- Inviting a lawyer creates a **pending** row — no rep points awarded until they accept
- Invitee sees Accept/Decline buttons in the bell notification dropdown
- Accepting flips status to `accepted` and awards 30 reputation points
- Declining removes the row entirely
- Overview tab shows **Pending** badge for uninvited members so the inviter can track responses
- Bell badge count = pending invites + new reputation events since last seen

## Test plan
- [ ] Invite a lawyer from Connect tab → Overview shows them as Pending
- [ ] Log in as invitee → bell shows red badge with Accept/Decline buttons
- [ ] Accept → badge clears, Overview updates to Collaborator, +30 pts in activity
- [ ] Decline → invite disappears, lawyer not shown in Overview
- [ ] Inviter's bell shows +20 pts activity event after sending invite

Closes #73