### PR TITLE
fix: context briefs null safety, membership guards, timeout config (#74)

### DIFF
--- a/app/api/context/[briefId]/route.ts
+++ b/app/api/context/[briefId]/route.ts
@@ -48,6 +48,7 @@ export async function GET(
     .select("role")
     .eq("matter_id", brief.matter_id)
     .eq("lawyer_id", lawyer.id)
+    .eq("status", "accepted")
     .maybeSingle();
 
   if (membershipError || !membership) {

--- a/app/api/context/generate/route.ts
+++ b/app/api/context/generate/route.ts
@@ -56,6 +56,7 @@ export async function POST(req: Request) {
     .select("role")
     .eq("matter_id", matter_id)
     .eq("lawyer_id", lawyer.id)
+    .eq("status", "accepted")
     .maybeSingle();
 
   if (membershipError || !membership) {

--- a/app/api/matters/route.ts
+++ b/app/api/matters/route.ts
@@ -126,7 +126,8 @@ export async function GET(req: Request) {
   const { data: teamRows, error: teamError } = await service
     .from("matter_team")
     .select("matter_id")
-    .eq("lawyer_id", lawyer.id);
+    .eq("lawyer_id", lawyer.id)
+    .eq("status", "accepted");
 
   if (teamError) {
     return NextResponse.json({ error: "Failed to load matters" }, { status: 500 });

--- a/app/matters/[id]/context/_components/ContextTab.tsx
+++ b/app/matters/[id]/context/_components/ContextTab.tsx
@@ -150,7 +150,7 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Failed to generate briefs");
 
-      setBriefs(data.briefs as Brief[]);
+      setBriefs((data.briefs as Brief[]) ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
       setBriefs((prev) => prev.filter((b) => !b.id.startsWith("pending-")));
@@ -200,7 +200,7 @@ export default function ContextTab({ matterId, initialBriefs, jurisdictions }: P
       )}
 
       {/* Empty / preparing state */}
-      {briefs.length === 0 && !isGenerating && (
+      {briefs.length === 0 && !isGenerating && !error && (
         <div className="flex flex-col items-center justify-center py-20 text-center">
           <Sparkles className="w-8 h-8 text-brand-purple/40 mb-3" />
           <p className="text-sm font-medium text-gray-500">Preparing briefs…</p>

--- a/lib/ai/groq.ts
+++ b/lib/ai/groq.ts
@@ -56,6 +56,8 @@ Be specific and practical. Prioritise information a senior lawyer would need bef
 const REQUIRED_FIELDS = ["legal_landscape", "cultural_intelligence", "regulatory_notes"] as const;
 
 function parseBriefResponse(raw: string): BriefContent {
+  if (!raw) throw new Error("Groq returned an empty response");
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -64,14 +66,14 @@ function parseBriefResponse(raw: string): BriefContent {
     throw new Error("Groq returned non-JSON content");
   }
 
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Groq response is not a JSON object");
+  }
+
   const obj = parsed as Record<string, unknown>;
   const missing = REQUIRED_FIELDS.filter((k) => typeof obj[k] !== "string");
 
-  if (
-    typeof parsed !== "object" ||
-    parsed === null ||
-    missing.length > 0
-  ) {
+  if (missing.length > 0) {
     throw new Error(
       `Groq response is missing required fields: ${missing.join(", ")}. Got keys: ${Object.keys(obj).join(", ")}`
     );

--- a/lib/ai/groq.ts
+++ b/lib/ai/groq.ts
@@ -56,7 +56,7 @@ Be specific and practical. Prioritise information a senior lawyer would need bef
 const REQUIRED_FIELDS = ["legal_landscape", "cultural_intelligence", "regulatory_notes"] as const;
 
 function parseBriefResponse(raw: string): BriefContent {
-  if (!raw) throw new Error("Groq returned an empty response");
+  if (!raw?.trim()) throw new Error("Groq returned an empty response");
 
   let parsed: unknown;
   try {
@@ -71,7 +71,9 @@ function parseBriefResponse(raw: string): BriefContent {
   }
 
   const obj = parsed as Record<string, unknown>;
-  const missing = REQUIRED_FIELDS.filter((k) => typeof obj[k] !== "string");
+  const missing = REQUIRED_FIELDS.filter(
+    (k) => typeof obj[k] !== "string" || (obj[k] as string).trim().length === 0
+  );
 
   if (missing.length > 0) {
     throw new Error(

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,8 @@
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "devCommand": "npm run dev",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "functions": {
+    "app/api/context/generate/route.ts": { "maxDuration": 60 }
+  }
 }


### PR DESCRIPTION
## Summary
- `parseBriefResponse`: empty string and null checks before accessing object keys — prevents TypeError when Groq returns empty/null content
- `ContextTab`: `data.briefs ?? []` guard prevents undefined state crash on unexpected API response
- `ContextTab`: added `!error` to empty state condition so error banner and "Preparing briefs…" don't render simultaneously
- `generate` + `[briefId]` routes: membership check now requires `status = 'accepted'` — pending invitees can't trigger generation or poll briefs
- `matters GET`: filters `matter_team` by `status = 'accepted'` so pending invites don't appear in the matters list
- `vercel.json`: `maxDuration: 60` on the generate route as a safety net against Vercel's default 10s limit

## Test plan
- [ ] Generate briefs on a matter — all 4 cards appear and complete without error
- [ ] Simulate Groq null response — brief shows error state, no crash
- [ ] Pending invitee cannot see matter in their list before accepting
- [ ] Pending invitee cannot trigger brief generation

Closes #74