### PR TITLE
feat(reputation): leaderboard search + sticky self-profile row (#77)

### DIFF
--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -59,11 +59,16 @@ export async function GET(request: Request) {
   }
 
   // Resolve current user's lawyer record
-  const { data: currentLawyer } = await supabase
-    .from("lawyers")
-    .select("id, full_name, office_city, office_country, reputation_score, avatar_url, matters_count")
-    .eq("email", user.email!)
-    .maybeSingle();
+  let currentLawyer: { id: string; full_name: string; office_city: string; office_country: string; reputation_score: number; avatar_url: string | null; matters_count: number } | null = null;
+  if (user.email) {
+    const { data, error: currentLawyerError } = await supabase
+      .from("lawyers")
+      .select("id, full_name, office_city, office_country, reputation_score, avatar_url, matters_count")
+      .eq("email", user.email)
+      .maybeSingle();
+    if (currentLawyerError) return NextResponse.json({ error: currentLawyerError.message }, { status: 500 });
+    currentLawyer = data;
+  }
 
   // Leaderboard: top 20 by reputation_score, stable secondary sort by full_name
   const { data: leaderboard, error } = await supabase

--- a/app/api/reputation/route.ts
+++ b/app/api/reputation/route.ts
@@ -58,6 +58,13 @@ export async function GET(request: Request) {
     });
   }
 
+  // Resolve current user's lawyer record
+  const { data: currentLawyer } = await supabase
+    .from("lawyers")
+    .select("id, full_name, office_city, office_country, reputation_score, avatar_url, matters_count")
+    .eq("email", user.email!)
+    .maybeSingle();
+
   // Leaderboard: top 20 by reputation_score, stable secondary sort by full_name
   const { data: leaderboard, error } = await supabase
     .from("lawyers")
@@ -73,5 +80,19 @@ export async function GET(request: Request) {
     rank: idx + 1,
   }));
 
-  return NextResponse.json({ leaderboard: enriched });
+  const current_lawyer_id = currentLawyer?.id ?? null;
+  const inTop20 = enriched.some((l) => l.id === current_lawyer_id);
+
+  // If current user is outside top 20, compute their real rank and include their full entry
+  let self_entry: (typeof enriched)[number] | null = null;
+  if (currentLawyer && !inTop20) {
+    const { count } = await supabase
+      .from("lawyers")
+      .select("*", { count: "exact", head: true })
+      .gt("reputation_score", currentLawyer.reputation_score);
+
+    self_entry = { ...currentLawyer, rank: (count ?? 0) + 1 };
+  }
+
+  return NextResponse.json({ leaderboard: enriched, current_lawyer_id, self_entry });
 }

--- a/app/reputation/_components/LeaderboardTable.tsx
+++ b/app/reputation/_components/LeaderboardTable.tsx
@@ -136,6 +136,7 @@ export default function LeaderboardTable({ leaderboard, selectedId, onSelect, cu
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search by name…"
+            aria-label="Search by name"
             className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-purple/40"
           />
         </div>

--- a/app/reputation/_components/LeaderboardTable.tsx
+++ b/app/reputation/_components/LeaderboardTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+import { Search } from "lucide-react";
 import { getBadge } from "@/lib/reputation/badges";
 
 interface LeaderboardEntry {
@@ -17,6 +19,8 @@ interface Props {
   leaderboard: LeaderboardEntry[];
   selectedId: string | null;
   onSelect: (id: string) => void;
+  currentLawyerId: string | null;
+  selfEntry: LeaderboardEntry | null;
 }
 
 function Initials({ name }: { name: string }) {
@@ -30,9 +34,113 @@ const RANK_STYLES: Record<number, string> = {
   3: "text-orange-500 font-bold",
 };
 
-export default function LeaderboardTable({ leaderboard, selectedId, onSelect }: Props) {
+function LawyerRow({
+  entry,
+  isSelected,
+  isYou,
+  onSelect,
+}: {
+  entry: LeaderboardEntry;
+  isSelected: boolean;
+  isYou: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const badge = getBadge(entry.reputation_score);
+  return (
+    <tr
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      onClick={() => onSelect(entry.id)}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(entry.id); } }}
+      className={`cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-purple ${
+        isYou
+          ? "bg-brand-purple/5 border-l-2 border-brand-purple hover:bg-brand-purple/10"
+          : isSelected
+          ? "bg-brand-purple/5 hover:bg-brand-purple/5"
+          : "hover:bg-gray-50"
+      }`}
+    >
+      {/* Rank */}
+      <td className="px-4 py-3 text-sm">
+        <span className={RANK_STYLES[entry.rank] ?? "text-gray-400 font-medium"}>
+          {entry.rank}
+        </span>
+      </td>
+
+      {/* Avatar + name */}
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
+            <span className="text-[11px] font-semibold text-brand-purple">
+              <Initials name={entry.full_name} />
+            </span>
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <p className="font-medium text-gray-900 leading-tight">{entry.full_name}</p>
+              {isYou && (
+                <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-brand-purple text-white leading-none">
+                  You
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-gray-400">{entry.office_city}, {entry.office_country}</p>
+          </div>
+        </div>
+      </td>
+
+      {/* Badge */}
+      <td className="px-4 py-3 hidden sm:table-cell">
+        <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${badge.color}`}>
+          {badge.label}
+        </span>
+      </td>
+
+      {/* Matters */}
+      <td className="px-4 py-3 text-right text-gray-500 hidden sm:table-cell">
+        {entry.matters_count ?? 0}
+      </td>
+
+      {/* Score */}
+      <td className="px-4 py-3 text-right">
+        <span className={`font-semibold ${isSelected || isYou ? "text-brand-purple" : "text-gray-900"}`}>
+          {entry.reputation_score.toLocaleString()}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+export default function LeaderboardTable({ leaderboard, selectedId, onSelect, currentLawyerId, selfEntry }: Props) {
+  const [search, setSearch] = useState("");
+
+  const query = search.trim().toLowerCase();
+  const filtered = query
+    ? leaderboard.filter((e) => e.full_name.toLowerCase().includes(query))
+    : leaderboard;
+
+  // Pin self-row only when the user is outside the currently visible (filtered) list
+  const selfInFiltered = currentLawyerId ? filtered.some((e) => e.id === currentLawyerId) : false;
+  const selfMatchesSearch = selfEntry && (!query || selfEntry.full_name.toLowerCase().includes(query));
+  const showPinnedSelf = selfEntry && selfMatchesSearch && !selfInFiltered;
+
   return (
     <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+      {/* Search */}
+      <div className="px-4 py-3 border-b border-gray-100">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name…"
+            className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-purple/40"
+          />
+        </div>
+      </div>
+
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-100 bg-gray-50">
@@ -44,67 +152,42 @@ export default function LeaderboardTable({ leaderboard, selectedId, onSelect }: 
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-50">
-          {leaderboard.map((entry) => {
-            const badge = getBadge(entry.reputation_score);
-            const isSelected = entry.id === selectedId;
-
-            return (
-              <tr
+          {filtered.length === 0 && !showPinnedSelf ? (
+            <tr>
+              <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-400">
+                No results for &ldquo;{search}&rdquo;
+              </td>
+            </tr>
+          ) : (
+            filtered.map((entry) => (
+              <LawyerRow
                 key={entry.id}
-                role="button"
-                tabIndex={0}
-                aria-pressed={isSelected}
-                onClick={() => onSelect(entry.id)}
-                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(entry.id); } }}
-                className={`cursor-pointer transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-purple ${
-                  isSelected ? "bg-brand-purple/5 hover:bg-brand-purple/5" : ""
-                }`}
-              >
-                {/* Rank */}
-                <td className="px-4 py-3 text-sm">
-                  <span className={RANK_STYLES[entry.rank] ?? "text-gray-400 font-medium"}>
-                    {entry.rank}
-                  </span>
-                </td>
-
-                {/* Avatar + name */}
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
-                      <span className="text-[11px] font-semibold text-brand-purple">
-                        <Initials name={entry.full_name} />
-                      </span>
-                    </div>
-                    <div>
-                      <p className="font-medium text-gray-900 leading-tight">{entry.full_name}</p>
-                      <p className="text-xs text-gray-400">{entry.office_city}, {entry.office_country}</p>
-                    </div>
-                  </div>
-                </td>
-
-                {/* Badge */}
-                <td className="px-4 py-3 hidden sm:table-cell">
-                  <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${badge.color}`}>
-                    {badge.label}
-                  </span>
-                </td>
-
-                {/* Matters */}
-                <td className="px-4 py-3 text-right text-gray-500 hidden sm:table-cell">
-                  {entry.matters_count ?? 0}
-                </td>
-
-                {/* Score */}
-                <td className="px-4 py-3 text-right">
-                  <span className={`font-semibold ${isSelected ? "text-brand-purple" : "text-gray-900"}`}>
-                    {entry.reputation_score.toLocaleString()}
-                  </span>
-                </td>
-              </tr>
-            );
-          })}
+                entry={entry}
+                isSelected={entry.id === selectedId}
+                isYou={entry.id === currentLawyerId}
+                onSelect={onSelect}
+              />
+            ))
+          )}
         </tbody>
       </table>
+
+      {/* Pinned self-row — shown when user is ranked outside the visible list */}
+      {showPinnedSelf && (
+        <>
+          <div className="border-t-2 border-dashed border-brand-purple/30" />
+          <table className="w-full text-sm">
+            <tbody>
+              <LawyerRow
+                entry={selfEntry!}
+                isSelected={selfEntry!.id === selectedId}
+                isYou
+                onSelect={onSelect}
+              />
+            </tbody>
+          </table>
+        </>
+      )}
     </div>
   );
 }

--- a/app/reputation/page.tsx
+++ b/app/reputation/page.tsx
@@ -21,6 +21,8 @@ export default function ReputationPage() {
   const router = useRouter();
 
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [currentLawyerId, setCurrentLawyerId] = useState<string | null>(null);
+  const [selfEntry, setSelfEntry] = useState<LeaderboardEntry | null>(null);
   const [loadingBoard, setLoadingBoard] = useState(true);
   const [boardError, setBoardError] = useState<string | null>(null);
 
@@ -43,7 +45,11 @@ export default function ReputationPage() {
       .then((data) => {
         if (!data) return;
         setLeaderboard(data.leaderboard ?? []);
-        if (data.leaderboard?.length) setSelectedId(data.leaderboard[0].id);
+        setCurrentLawyerId(data.current_lawyer_id ?? null);
+        setSelfEntry(data.self_entry ?? null);
+        // Auto-select current user, otherwise first entry
+        const autoSelect = data.current_lawyer_id ?? data.leaderboard?.[0]?.id ?? null;
+        if (autoSelect) setSelectedId(autoSelect);
       })
       .catch((err) => setBoardError(err.message))
       .finally(() => setLoadingBoard(false));
@@ -103,6 +109,8 @@ export default function ReputationPage() {
               leaderboard={leaderboard}
               selectedId={selectedId}
               onSelect={setSelectedId}
+              currentLawyerId={currentLawyerId}
+              selfEntry={selfEntry}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- Search input filters the leaderboard by name in real time (client-side)
- API returns `current_lawyer_id` and `self_entry` with real rank when user is outside top 20
- Current user's row always highlighted with purple left border + "You" badge
- If user is in top 20: highlighted naturally in position
- If user is outside top 20: pinned below a dashed separator with their real rank
- Page auto-selects the current user's row on load

## Test plan
- [ ] Search filters the list in real time
- [ ] Logged-in user's row shows "You" badge and purple left border
- [ ] If user is in top 20: row appears in position with highlight
- [ ] If user is outside top 20: row is pinned at the bottom with their real rank
- [ ] Clicking the pinned row loads their detail panel