### PR TITLE
fix(layout): sidebar fixed to viewport, only content scrolls

### DIFF
--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import Sidebar from "./Sidebar";
 import TopBar from "./TopBar";
@@ -9,6 +10,13 @@ const AUTH_PATHS = ["/login", "/signup", "/auth/callback"];
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isAuthPage = AUTH_PATHS.some((p) => pathname.startsWith(p));
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Scrolling now happens inside this container, not on `window` — so Next.js'
+  // default scroll-to-top on route change doesn't fire. Reset it ourselves.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: 0, left: 0 });
+  }, [pathname]);
 
   if (isAuthPage) return <>{children}</>;
 
@@ -23,7 +31,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </div>
         {/* pt-14 offsets the fixed mobile top bar on small screens */}
         {/* Pages render their own <main> inside this scrollable wrapper */}
-        <div className="flex-1 overflow-y-auto pt-14 lg:pt-0">
+        <div ref={scrollRef} className="flex-1 overflow-y-auto pt-14 lg:pt-0">
           {children}
         </div>
       </div>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -13,15 +13,16 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   if (isAuthPage) return <>{children}</>;
 
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <div className="flex h-screen overflow-hidden bg-gray-50">
       <Sidebar />
       {/* Right side: top bar + page content */}
-      <div className="flex-1 flex flex-col min-w-0">
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {/* TopBar is hidden on mobile (Sidebar handles the mobile header) */}
         <div className="hidden lg:block">
           <TopBar />
         </div>
         {/* pt-14 offsets the fixed mobile top bar on small screens */}
+        {/* Pages render their own <main> inside this scrollable wrapper */}
         <div className="flex-1 overflow-y-auto pt-14 lg:pt-0">
           {children}
         </div>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -66,7 +66,7 @@ export default function Sidebar() {
   return (
     <>
       {/* ── Desktop sidebar (lg+) ─────────────────────────────────────── */}
-      <aside className="hidden lg:flex w-60 min-h-screen bg-brand-purple flex-col flex-shrink-0">
+      <aside className="hidden lg:flex w-60 h-screen bg-brand-purple flex-col flex-shrink-0">
         <div className="p-6 border-b border-white/10">
           <Logo />
         </div>


### PR DESCRIPTION
## Summary
- `components/layout/AppShell.tsx`: outer wrapper changed from `min-h-screen` to `h-screen overflow-hidden`, right column gets `overflow-hidden`. Comment added clarifying that pages render their own `<main>` inside the scrollable wrapper (the wrapper itself is a `<div>` to avoid nested-`<main>` invalid HTML).
- `components/layout/Sidebar.tsx`: desktop `<aside>` changed from `min-h-screen` to `h-screen` so it stays bounded by the viewport-height parent.

The mobile fixed top bar (z-40, outside the flex flow) and the `pt-14 lg:pt-0` offset on the content wrapper are unchanged — mobile behavior is preserved.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Desktop: scroll a long page (lawyer profile, dashboard) — sidebar stays put, only content area scrolls
- [ ] Tablet (768px): hamburger menu still opens/closes correctly, content scrolls within the viewport
- [ ] Mobile (375px): fixed top bar stays put, content scrolls underneath it without bleeding above

Closes #78