### PR TITLE
fix(layout): mobile profile icon shows initials, not 'Me'

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { LayoutDashboard, Users, Briefcase, FileText, Award, LogOut, Menu, X } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
+import { useCurrentLawyer, getInitials } from "@/lib/hooks/useCurrentLawyer";
 
 const navItems = [
   { href: "/dashboard",   label: "Dashboard",   icon: LayoutDashboard },
@@ -54,6 +56,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const supabase = createClient();
+  const lawyer = useCurrentLawyer();
   const [mobileOpen, setMobileOpen] = useState(false);
 
   async function handleSignOut() {
@@ -88,8 +91,24 @@ export default function Sidebar() {
       <div className="lg:hidden fixed top-0 left-0 right-0 z-40 bg-brand-purple flex items-center justify-between px-4 h-14 border-b border-white/10">
         <Logo />
         <div className="flex items-center gap-2">
-          <Link href="/profile" className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center hover:bg-white/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60">
-            <span className="text-white text-xs font-semibold">Me</span>
+          <Link
+            href="/profile"
+            aria-label="My profile"
+            className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center overflow-hidden hover:bg-white/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            {lawyer?.avatarUrl ? (
+              <Image
+                src={lawyer.avatarUrl}
+                alt={lawyer.name}
+                width={28}
+                height={28}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <span className="text-white text-xs font-semibold">
+                {lawyer ? getInitials(lawyer.name) : ""}
+              </span>
+            )}
           </Link>
           <button
             onClick={() => setMobileOpen(true)}

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -4,17 +4,10 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Bell, Loader2 } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
+import { useCurrentLawyer, getInitials } from "@/lib/hooks/useCurrentLawyer";
 import type { PendingInvite, ActivityEvent } from "@/app/api/notifications/route";
 
 const STORAGE_KEY = "bell_last_seen";
-
-function getInitials(name: string) {
-  const parts = name.trim().split(" ");
-  return parts.length >= 2
-    ? `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
-    : name[0].toUpperCase();
-}
 
 function relativeTime(date: string): string {
   const diff = Date.now() - new Date(date).getTime();
@@ -78,8 +71,7 @@ function InviteRow({
 }
 
 export default function TopBar() {
-  const [name, setName] = useState<string | null>(null);
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const lawyer = useCurrentLawyer();
   const [invites, setInvites] = useState<PendingInvite[]>([]);
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [bellOpen, setBellOpen] = useState(false);
@@ -92,22 +84,6 @@ export default function TopBar() {
       const parsed = parseInt(stored, 10);
       if (Number.isFinite(parsed)) setLastSeen(parsed);
     }
-  }, []);
-
-  useEffect(() => {
-    const supabase = createClient();
-    supabase.auth.getUser().then(async ({ data: { user } }) => {
-      if (!user) return;
-      const { data } = await supabase
-        .from("lawyers")
-        .select("full_name, avatar_url")
-        .eq("email", user.email)
-        .single();
-      if (data) {
-        setName(data.full_name);
-        setAvatarUrl(data.avatar_url ?? null);
-      }
-    });
   }, []);
 
   const fetchNotifications = useCallback(async () => {
@@ -162,7 +138,8 @@ export default function TopBar() {
     }
   }
 
-  if (!name) return null;
+  if (!lawyer) return null;
+  const { name, avatarUrl } = lawyer;
 
   const hasContent = invites.length > 0 || events.length > 0;
 

--- a/lib/hooks/useCurrentLawyer.ts
+++ b/lib/hooks/useCurrentLawyer.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export type CurrentLawyer = {
+  name: string;
+  avatarUrl: string | null;
+};
+
+/**
+ * Returns the logged-in user's lawyer profile (name + avatar) for header chrome.
+ * Returns `null` while loading or if no matching lawyer row exists.
+ *
+ * Used by both the desktop TopBar and the mobile top bar in Sidebar so they
+ * stay in sync without duplicate Supabase fetches.
+ */
+export function useCurrentLawyer(): CurrentLawyer | null {
+  const [lawyer, setLawyer] = useState<CurrentLawyer | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+
+    supabase.auth.getUser().then(async ({ data: { user } }) => {
+      if (cancelled || !user?.email) return;
+      const { data } = await supabase
+        .from("lawyers")
+        .select("full_name, avatar_url")
+        .eq("email", user.email)
+        .maybeSingle();
+      if (cancelled || !data) return;
+      setLawyer({
+        name: data.full_name as string,
+        avatarUrl: (data.avatar_url as string | null) ?? null,
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return lawyer;
+}
+
+export function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+}

--- a/lib/hooks/useCurrentLawyer.ts
+++ b/lib/hooks/useCurrentLawyer.ts
@@ -8,34 +8,57 @@ export type CurrentLawyer = {
   avatarUrl: string | null;
 };
 
+// Module-level cache + in-flight promise so multiple components mounting at
+// once (TopBar + Sidebar) share a single Supabase fetch instead of racing.
+let cached: CurrentLawyer | null = null;
+let inflight: Promise<CurrentLawyer | null> | null = null;
+
+async function fetchCurrentLawyer(): Promise<CurrentLawyer | null> {
+  if (cached) return cached;
+  if (inflight) return inflight;
+
+  inflight = (async () => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user?.email) return null;
+
+    const { data } = await supabase
+      .from("lawyers")
+      .select("full_name, avatar_url")
+      .eq("email", user.email)
+      .maybeSingle();
+    if (!data) return null;
+
+    cached = {
+      name: data.full_name as string,
+      avatarUrl: (data.avatar_url as string | null) ?? null,
+    };
+    return cached;
+  })().finally(() => {
+    inflight = null;
+  });
+
+  return inflight;
+}
+
 /**
  * Returns the logged-in user's lawyer profile (name + avatar) for header chrome.
  * Returns `null` while loading or if no matching lawyer row exists.
  *
- * Used by both the desktop TopBar and the mobile top bar in Sidebar so they
- * stay in sync without duplicate Supabase fetches.
+ * Backed by a module-level cache + in-flight promise dedup, so simultaneous
+ * mounts of TopBar and Sidebar share a single Supabase round-trip.
  */
 export function useCurrentLawyer(): CurrentLawyer | null {
-  const [lawyer, setLawyer] = useState<CurrentLawyer | null>(null);
+  const [lawyer, setLawyer] = useState<CurrentLawyer | null>(cached);
 
   useEffect(() => {
+    if (cached) return;
     let cancelled = false;
-    const supabase = createClient();
-
-    supabase.auth.getUser().then(async ({ data: { user } }) => {
-      if (cancelled || !user?.email) return;
-      const { data } = await supabase
-        .from("lawyers")
-        .select("full_name, avatar_url")
-        .eq("email", user.email)
-        .maybeSingle();
-      if (cancelled || !data) return;
-      setLawyer({
-        name: data.full_name as string,
-        avatarUrl: (data.avatar_url as string | null) ?? null,
-      });
+    void fetchCurrentLawyer().then((result) => {
+      if (!cancelled && result) setLawyer(result);
     });
-
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## Summary
- `lib/hooks/useCurrentLawyer.ts`: new shared client hook that fetches the logged-in user's lawyer profile (`full_name`, `avatar_url`) once. Exports `getInitials()` so the same name → initials logic is used everywhere.
- `components/layout/TopBar.tsx`: replaces its inline Supabase fetch and local `getInitials` with the hook.
- `components/layout/Sidebar.tsx`: mobile/tablet top bar now consumes the same hook — renders `<Image>` if the lawyer has an `avatar_url`, otherwise initials. Hardcoded `"Me"` removed.

Both components now stay in sync without duplicate Supabase calls.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Mobile (375px) and tablet (768px): profile circle shows initials (e.g. "MC" for Marcus Chen) — no longer "Me"
- [ ] Desktop TopBar still shows the same initials (consistency check)
- [ ] If a lawyer has an `avatar_url` set, the avatar appears on mobile too

Closes #79