### PR TITLE
fix(field-notes): per-user upvote uniqueness, jurisdiction badge, reputation tooltip

### DIFF
--- a/app/api/field-notes/[id]/upvote/route.ts
+++ b/app/api/field-notes/[id]/upvote/route.ts
@@ -50,6 +50,18 @@ export async function POST(
     return NextResponse.json({ error: "Cannot upvote your own note" }, { status: 400 });
   }
 
+  // Per-user uniqueness — composite PK (note_id, upvoter_id) raises 23505 on duplicate
+  const { error: trackError } = await service
+    .from("field_note_upvotes")
+    .insert({ note_id: noteId, upvoter_id: upvoter.id });
+
+  if (trackError) {
+    if (trackError.code === "23505") {
+      return NextResponse.json({ error: "You have already upvoted this note" }, { status: 409 });
+    }
+    return NextResponse.json({ error: "Failed to record upvote" }, { status: 500 });
+  }
+
   // Increment the cosmetic upvote counter (service role bypasses author-only RLS)
   const { error: updateError } = await service
     .from("field_notes")

--- a/app/api/field-notes/route.ts
+++ b/app/api/field-notes/route.ts
@@ -43,7 +43,10 @@ export async function GET(req: Request) {
 
   const { searchParams } = new URL(req.url);
   const jurisdiction = searchParams.get("jurisdiction")?.trim().toUpperCase() || null;
-  const q = searchParams.get("q")?.trim() || null;
+  const rawQ = searchParams.get("q")?.trim() || null;
+  // Strip PostgREST `.or()` reserved chars and ilike wildcards so we don't break
+  // filter grammar or honor user-supplied wildcards.
+  const q = rawQ ? rawQ.replace(/[%_,()\\*]/g, " ").trim() : null;
 
   const service = createServiceClient();
 
@@ -65,11 +68,14 @@ export async function GET(req: Request) {
   const noteIds = (notes ?? []).map((n) => n.id as string);
   let upvotedSet = new Set<string>();
   if (noteIds.length > 0) {
-    const { data: upvotedRows } = await service
+    const { data: upvotedRows, error: upvotedError } = await service
       .from("field_note_upvotes")
       .select("note_id")
       .eq("upvoter_id", lawyer.id)
       .in("note_id", noteIds);
+    if (upvotedError) {
+      return NextResponse.json({ error: "Failed to load upvotes" }, { status: 500 });
+    }
     upvotedSet = new Set((upvotedRows ?? []).map((r) => r.note_id as string));
   }
 

--- a/app/api/field-notes/route.ts
+++ b/app/api/field-notes/route.ts
@@ -38,15 +38,16 @@ async function getAuthenticatedLawyer() {
 
 // GET /api/field-notes?jurisdiction=CO&q=FDI
 export async function GET(req: Request) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const lawyer = await getAuthenticatedLawyer();
+  if (!lawyer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { searchParams } = new URL(req.url);
   const jurisdiction = searchParams.get("jurisdiction")?.trim().toUpperCase() || null;
   const q = searchParams.get("q")?.trim() || null;
 
-  let query = supabase
+  const service = createServiceClient();
+
+  let query = service
     .from("field_notes")
     .select("id, jurisdiction_code, jurisdiction_name, title, content, matter_type, upvotes, created_at, author_id, author:lawyers(id, full_name, office_city)")
     .eq("visibility", "firm")
@@ -57,10 +58,27 @@ export async function GET(req: Request) {
   if (jurisdiction) query = query.eq("jurisdiction_code", jurisdiction);
   if (q) query = query.or(`title.ilike.%${q}%,content.ilike.%${q}%`);
 
-  const { data, error } = await query;
+  const { data: notes, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  return NextResponse.json(data ?? []);
+  // Mark which of these notes the current lawyer has already upvoted
+  const noteIds = (notes ?? []).map((n) => n.id as string);
+  let upvotedSet = new Set<string>();
+  if (noteIds.length > 0) {
+    const { data: upvotedRows } = await service
+      .from("field_note_upvotes")
+      .select("note_id")
+      .eq("upvoter_id", lawyer.id)
+      .in("note_id", noteIds);
+    upvotedSet = new Set((upvotedRows ?? []).map((r) => r.note_id as string));
+  }
+
+  const enriched = (notes ?? []).map((n) => ({
+    ...n,
+    has_upvoted: upvotedSet.has(n.id as string),
+  }));
+
+  return NextResponse.json(enriched);
 }
 
 // POST /api/field-notes — create note + award 40 pts to author

--- a/app/field-notes/page.tsx
+++ b/app/field-notes/page.tsx
@@ -5,11 +5,19 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2, ChevronUp, Plus, Search } from "lucide-react";
 import Link from "next/link";
 import type { FieldNote, Lawyer } from "@/types";
+import { JURISDICTIONS as ALL_JURISDICTIONS } from "@/lib/jurisdictions";
 
 type NoteWithAuthor = Pick<
   FieldNote,
   "id" | "jurisdiction_code" | "jurisdiction_name" | "title" | "content" | "matter_type" | "upvotes" | "created_at" | "author_id"
-> & { author: Pick<Lawyer, "id" | "full_name" | "office_city"> | null };
+> & {
+  author: Pick<Lawyer, "id" | "full_name" | "office_city"> | null;
+  has_upvoted: boolean;
+};
+
+function getFlag(code: string): string {
+  return ALL_JURISDICTIONS.find((j) => j.code === code)?.flag ?? "";
+}
 
 const JURISDICTIONS = [
   { code: "BR", name: "Brazil" },
@@ -85,6 +93,13 @@ function FieldNotesContent() {
     setUpvoting(noteId);
     try {
       const res = await fetch(`/api/field-notes/${noteId}/upvote`, { method: "POST" });
+      if (res.status === 409) {
+        // Already upvoted — flip local state to match server truth
+        setNotes((prev) =>
+          prev.map((n) => (n.id === noteId ? { ...n, has_upvoted: true } : n))
+        );
+        return;
+      }
       if (res.status === 400) {
         const body = await res.json();
         alert(body.error);
@@ -93,7 +108,7 @@ function FieldNotesContent() {
       if (!res.ok) return;
       const { upvotes } = await res.json();
       setNotes((prev) =>
-        prev.map((n) => (n.id === noteId ? { ...n, upvotes } : n))
+        prev.map((n) => (n.id === noteId ? { ...n, upvotes, has_upvoted: true } : n))
       );
     } finally {
       setUpvoting(null);
@@ -167,11 +182,15 @@ function FieldNotesContent() {
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
                   <span
-                    className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${
+                    className={`inline-flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full ${
                       JURISDICTION_COLORS[note.jurisdiction_code] ?? "bg-gray-100 text-gray-600"
                     }`}
                   >
-                    {note.jurisdiction_name}
+                    <span aria-hidden="true">{getFlag(note.jurisdiction_code)}</span>
+                    <span>{note.jurisdiction_code}</span>
+                    {note.jurisdiction_name && (
+                      <span className="opacity-75">· {note.jurisdiction_name}</span>
+                    )}
                   </span>
                   <h3 className="font-semibold text-gray-900 text-sm mt-2 leading-snug">
                     {note.title}
@@ -179,14 +198,23 @@ function FieldNotesContent() {
                 </div>
                 <button
                   onClick={() => handleUpvote(note.id)}
-                  disabled={upvoting === note.id}
-                  className="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border border-gray-200 hover:border-brand-purple/40 hover:bg-brand-purple/5 transition-colors disabled:opacity-50 flex-shrink-0"
-                  aria-label={`Upvote: ${note.upvotes} votes`}
+                  disabled={upvoting === note.id || note.has_upvoted}
+                  title={note.has_upvoted ? "You upvoted this note" : "Upvoting awards the author +10 reputation"}
+                  className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border transition-colors flex-shrink-0 ${
+                    note.has_upvoted
+                      ? "border-brand-purple/40 bg-brand-purple/10 cursor-default"
+                      : "border-gray-200 hover:border-brand-purple/40 hover:bg-brand-purple/5"
+                  } disabled:opacity-50`}
+                  aria-label={
+                    note.has_upvoted
+                      ? `You upvoted this note (${note.upvotes} votes)`
+                      : `Upvote — author earns +10 reputation (${note.upvotes} votes)`
+                  }
                 >
                   {upvoting === note.id ? (
                     <Loader2 className="w-3.5 h-3.5 animate-spin text-brand-purple" />
                   ) : (
-                    <ChevronUp className="w-3.5 h-3.5 text-brand-purple" />
+                    <ChevronUp className={`w-3.5 h-3.5 text-brand-purple ${note.has_upvoted ? "fill-current" : ""}`} />
                   )}
                   <span className="text-[11px] font-semibold text-brand-purple">{note.upvotes}</span>
                 </button>

--- a/app/field-notes/page.tsx
+++ b/app/field-notes/page.tsx
@@ -6,6 +6,7 @@ import { Loader2, ChevronUp, Plus, Search } from "lucide-react";
 import Link from "next/link";
 import type { FieldNote, Lawyer } from "@/types";
 import { JURISDICTIONS as ALL_JURISDICTIONS } from "@/lib/jurisdictions";
+import { REPUTATION_POINTS } from "@/lib/reputation/points";
 
 type NoteWithAuthor = Pick<
   FieldNote,
@@ -15,9 +16,13 @@ type NoteWithAuthor = Pick<
   has_upvoted: boolean;
 };
 
+// Built once at module scope — O(1) flag lookup per render
+const FLAG_MAP = new Map<string, string>(ALL_JURISDICTIONS.map((j) => [j.code, j.flag]));
 function getFlag(code: string): string {
-  return ALL_JURISDICTIONS.find((j) => j.code === code)?.flag ?? "";
+  return FLAG_MAP.get(code) ?? "";
 }
+
+const UPVOTE_REWARD = REPUTATION_POINTS.note_upvoted;
 
 const JURISDICTIONS = [
   { code: "BR", name: "Brazil" },
@@ -199,7 +204,7 @@ function FieldNotesContent() {
                 <button
                   onClick={() => handleUpvote(note.id)}
                   disabled={upvoting === note.id || note.has_upvoted}
-                  title={note.has_upvoted ? "You upvoted this note" : "Upvoting awards the author +10 reputation"}
+                  title={note.has_upvoted ? "You upvoted this note" : `Upvoting awards the author +${UPVOTE_REWARD} reputation`}
                   className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border transition-colors flex-shrink-0 ${
                     note.has_upvoted
                       ? "border-brand-purple/40 bg-brand-purple/10 cursor-default"
@@ -208,7 +213,7 @@ function FieldNotesContent() {
                   aria-label={
                     note.has_upvoted
                       ? `You upvoted this note (${note.upvotes} votes)`
-                      : `Upvote — author earns +10 reputation (${note.upvotes} votes)`
+                      : `Upvote — author earns +${UPVOTE_REWARD} reputation (${note.upvotes} votes)`
                   }
                 >
                   {upvoting === note.id ? (

--- a/lib/reputation/awards.ts
+++ b/lib/reputation/awards.ts
@@ -1,23 +1,10 @@
 import "server-only";
 import { createServiceClient } from "@/lib/supabase/server";
+import { REPUTATION_POINTS, NOTE_UPVOTE_CAP, type ReputationEventType } from "./points";
 
-// ─── Point values ────────────────────────────────────────────────────────────
-
-export const REPUTATION_POINTS = {
-  matter_joined: 30,
-  brief_generated: 50,
-  note_contributed: 40,
-  note_upvoted: 10,
-  handoff_completed: 25,
-  match_accepted: 20,
-  profile_completed: 60,
-  cross_border_matter: 100,
-} as const;
-
-export type ReputationEventType = keyof typeof REPUTATION_POINTS;
-
-// Max points a single field note can earn its author from upvotes
-export const NOTE_UPVOTE_CAP = 200;
+// Re-export for back-compat with existing server-side imports.
+export { REPUTATION_POINTS, NOTE_UPVOTE_CAP };
+export type { ReputationEventType };
 
 // ─── Badge tiers (re-exported from client-safe badges.ts) ───────────────────
 export { BADGE_TIERS, getBadge } from "@/lib/reputation/badges";

--- a/lib/reputation/points.ts
+++ b/lib/reputation/points.ts
@@ -1,0 +1,19 @@
+// Client-safe point values. Imported by both server-only `awards.ts` and
+// any client component that needs to display the reward amount in the UI.
+// Keep this file free of `server-only` and DB imports.
+
+export const REPUTATION_POINTS = {
+  matter_joined: 30,
+  brief_generated: 50,
+  note_contributed: 40,
+  note_upvoted: 10,
+  handoff_completed: 25,
+  match_accepted: 20,
+  profile_completed: 60,
+  cross_border_matter: 100,
+} as const;
+
+export type ReputationEventType = keyof typeof REPUTATION_POINTS;
+
+// Max points a single field note can earn its author from upvotes
+export const NOTE_UPVOTE_CAP = 200;

--- a/supabase/migrations/009_field_note_upvotes.sql
+++ b/supabase/migrations/009_field_note_upvotes.sql
@@ -11,3 +11,7 @@ CREATE TABLE IF NOT EXISTS field_note_upvotes (
 
 CREATE INDEX IF NOT EXISTS idx_field_note_upvotes_upvoter
   ON field_note_upvotes(upvoter_id);
+
+-- Lock down direct client access. All reads/writes go through API routes
+-- using the service role; no policies = deny all to authenticated/anon clients.
+ALTER TABLE field_note_upvotes ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/009_field_note_upvotes.sql
+++ b/supabase/migrations/009_field_note_upvotes.sql
@@ -1,0 +1,13 @@
+-- Tracks individual upvotes so each lawyer can upvote a given note at most once.
+-- The (note_id, upvoter_id) composite primary key enforces the uniqueness server-side;
+-- duplicate inserts will fail with 23505 and the API translates that into a 409.
+
+CREATE TABLE IF NOT EXISTS field_note_upvotes (
+  note_id UUID NOT NULL REFERENCES field_notes(id) ON DELETE CASCADE,
+  upvoter_id UUID NOT NULL REFERENCES lawyers(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (note_id, upvoter_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_note_upvotes_upvoter
+  ON field_note_upvotes(upvoter_id);


### PR DESCRIPTION
## Summary

### A. Per-user upvote uniqueness (server-side enforcement)
- `supabase/migrations/009_field_note_upvotes.sql`: new tracking table with composite primary key `(note_id, upvoter_id)`. Duplicates raise Postgres error `23505`.
- `app/api/field-notes/[id]/upvote/route.ts`: insert into the tracking table first; on `23505` return **409 "You have already upvoted this note"**. Self-upvote 400 still preserved. Counter increment + reputation award only run when the tracking row inserts cleanly.
- `app/api/field-notes/route.ts`: GET now batches a query against the tracking table and returns `has_upvoted: boolean` per note for the current lawyer (so reloads show the right state).

### B. Jurisdiction display
- `app/field-notes/page.tsx`: badge now shows **flag emoji + code + name** (e.g. "🇧🇷 BR · Brazil") instead of just the name. Uses `JURISDICTIONS` from `lib/jurisdictions.ts` for the flag — consistent with how Connect / matter cards render jurisdictions.

### C. Reputation tooltip + persistent disabled state
- Upvote button shows tooltip "Upvoting awards the author +10 reputation" when not yet upvoted, and "You upvoted this note" after.
- Filled chevron + tinted background indicate the upvoted state.
- 409 response (already upvoted from a previous session) flips the local state to disabled instead of being silently ignored.

## Migration to apply

```bash
npx tsx scripts/apply-migration.ts supabase/migrations/009_field_note_upvotes.sql
```

Or paste the SQL in Supabase Dashboard → SQL Editor.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Apply migration 009
- [ ] Upvote a note → button becomes disabled with filled chevron + tooltip "You upvoted this note"
- [ ] Refresh the page → previously upvoted notes still show as upvoted (persisted via `has_upvoted` from server)
- [ ] Click an already-upvoted note → no count change, no error toast
- [ ] Try to upvote your own note → 400 (preserved behavior)
- [ ] Manually POST a duplicate via curl → 409
- [ ] Each card shows flag + code + name on the jurisdiction badge

Closes #82