### PR TITLE
fix(cache): revalidate /dashboard and /matters after mutations

### DIFF
--- a/app/api/flow/tasks/[id]/route.ts
+++ b/app/api/flow/tasks/[id]/route.ts
@@ -1,5 +1,6 @@
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
 const updateTaskSchema = z.object({
@@ -82,6 +83,12 @@ export async function PATCH(
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  revalidatePath("/dashboard");
+  if (data?.matter_id) {
+    revalidatePath(`/matters/${data.matter_id}/flow`);
+  }
+
   return NextResponse.json(data);
 }
 

--- a/app/api/flow/tasks/route.ts
+++ b/app/api/flow/tasks/route.ts
@@ -1,5 +1,6 @@
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -107,5 +108,9 @@ export async function POST(request: Request) {
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  revalidatePath("/dashboard");
+  revalidatePath(`/matters/${parsed.data.matter_id}/flow`);
+
   return NextResponse.json(data, { status: 201 });
 }

--- a/app/api/matters/[id]/route.ts
+++ b/app/api/matters/[id]/route.ts
@@ -123,7 +123,8 @@ export async function PATCH(
 
   revalidatePath("/dashboard");
   revalidatePath("/matters");
-  revalidatePath(`/matters/${params.id}`);
+  // "layout" invalidates the entire matter subtree (overview/context/connect/flow)
+  revalidatePath(`/matters/${params.id}`, "layout");
 
   return NextResponse.json(matter);
 }

--- a/app/api/matters/[id]/route.ts
+++ b/app/api/matters/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 
@@ -119,6 +120,10 @@ export async function PATCH(
   if (error || !matter) {
     return NextResponse.json({ error: "Failed to update matter" }, { status: 500 });
   }
+
+  revalidatePath("/dashboard");
+  revalidatePath("/matters");
+  revalidatePath(`/matters/${params.id}`);
 
   return NextResponse.json(matter);
 }

--- a/app/api/matters/[id]/team/route.ts
+++ b/app/api/matters/[id]/team/route.ts
@@ -177,7 +177,9 @@ export async function POST(
   }
 
   revalidatePath("/dashboard");
-  revalidatePath(`/matters/${params.id}`);
+  revalidatePath("/matters");
+  // "layout" invalidates the entire matter subtree (overview/context/connect/flow)
+  revalidatePath(`/matters/${params.id}`, "layout");
 
   return NextResponse.json(newMember, { status: 201 });
 }
@@ -270,7 +272,7 @@ export async function PATCH(
 
   revalidatePath("/dashboard");
   revalidatePath("/matters");
-  revalidatePath(`/matters/${params.id}`);
+  revalidatePath(`/matters/${params.id}`, "layout");
 
   return NextResponse.json({ status: "accepted" });
 }

--- a/app/api/matters/[id]/team/route.ts
+++ b/app/api/matters/[id]/team/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 
@@ -175,6 +176,9 @@ export async function POST(
     ]);
   }
 
+  revalidatePath("/dashboard");
+  revalidatePath(`/matters/${params.id}`);
+
   return NextResponse.json(newMember, { status: 201 });
 }
 
@@ -227,6 +231,8 @@ export async function PATCH(
     if (deleteError) {
       return NextResponse.json({ error: "Failed to decline invite" }, { status: 500 });
     }
+    revalidatePath("/dashboard");
+    revalidatePath("/matters");
     return NextResponse.json({ status: "declined" });
   }
 
@@ -261,6 +267,10 @@ export async function PATCH(
         .eq("id", lawyer.id),
     ]);
   }
+
+  revalidatePath("/dashboard");
+  revalidatePath("/matters");
+  revalidatePath(`/matters/${params.id}`);
 
   return NextResponse.json({ status: "accepted" });
 }

--- a/app/api/matters/route.ts
+++ b/app/api/matters/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { getJurisdictionName } from "@/lib/jurisdictions";
@@ -100,6 +101,10 @@ export async function POST(req: Request) {
   // Context briefs are generated on demand from the Context tab UI via
   // POST /api/context/generate (issue #15). Not triggered here because
   // fire-and-forget is unreliable on Vercel Hobby (no waitUntil).
+
+  // Invalidate cached server pages that show matter counts/lists
+  revalidatePath("/dashboard");
+  revalidatePath("/matters");
 
   // Warm the Connect match cache non-blocking so the first Connect tab load is fast.
   void fetch(new URL("/api/connect/match", req.url).toString(), {


### PR DESCRIPTION
## Summary
After every API mutation that affects matter counts, task counts, or team membership, call \`revalidatePath\` on the affected server-rendered pages. Without this, the dashboard and matters list stay stale until a hard refresh.

### Routes updated
- \`app/api/matters/route.ts\` (POST) → \`/dashboard\`, \`/matters\`
- \`app/api/matters/[id]/route.ts\` (PATCH status/deadline) → \`/dashboard\`, \`/matters\`, \`/matters/[id]\`
- \`app/api/flow/tasks/route.ts\` (POST) → \`/dashboard\`, \`/matters/[id]/flow\`
- \`app/api/flow/tasks/[id]/route.ts\` (PATCH status/title/etc) → \`/dashboard\`, \`/matters/[matter_id]/flow\`
- \`app/api/matters/[id]/team/route.ts\` (POST invite, PATCH accept/decline) → \`/dashboard\`, \`/matters\`, \`/matters/[id]\`

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Create a matter → navigate back to /dashboard → Active Matters count increments without refresh
- [ ] Create a task → /dashboard Open Tasks increments
- [ ] Mark a task complete → /dashboard Open Tasks decrements
- [ ] Accept an invite → /matters list shows the new matter without refresh

Closes #83