### PR TITLE
fix(lawyers): back link respects matter context referrer

### DIFF
--- a/app/lawyers/[id]/page.tsx
+++ b/app/lawyers/[id]/page.tsx
@@ -25,8 +25,25 @@ function Initials({ name }: { name: string }) {
     : name[0];
 }
 
-export default async function LawyerProfilePage({ params }: { params: { id: string } }) {
+// Only allow internal paths back to a matter or the directory.
+// Anything else falls through to the default "Back to directory" link.
+function resolveBackLink(from: string | string[] | undefined): { href: string; label: string } {
+  const raw = Array.isArray(from) ? from[0] : from;
+  if (raw && /^\/matters\/[0-9a-f-]+(\/[a-z0-9-]+)?$/i.test(raw)) {
+    return { href: raw, label: "Back to matter" };
+  }
+  return { href: "/lawyers", label: "Back to directory" };
+}
+
+export default async function LawyerProfilePage({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams?: { from?: string | string[] };
+}) {
   const supabase = createClient();
+  const back = resolveBackLink(searchParams?.from);
 
   const [lawyerResult, jurisdictionsResult, eventsResult] = await Promise.all([
     supabase
@@ -65,11 +82,11 @@ export default async function LawyerProfilePage({ params }: { params: { id: stri
     <main className="flex-1 p-4 sm:p-6 lg:p-8 max-w-4xl">
       {/* Back */}
       <Link
-        href="/lawyers"
+        href={back.href}
         className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 transition-colors mb-6"
       >
         <ArrowLeft className="w-4 h-4" />
-        Back to directory
+        {back.label}
       </Link>
 
       {/* Hero */}

--- a/app/lawyers/[id]/page.tsx
+++ b/app/lawyers/[id]/page.tsx
@@ -25,11 +25,15 @@ function Initials({ name }: { name: string }) {
     : name[0];
 }
 
-// Only allow internal paths back to a matter or the directory.
-// Anything else falls through to the default "Back to directory" link.
+// Only allow internal paths back to a matter (with a canonical UUID and a
+// known tab segment) or the directory. Anything else falls through to the
+// default "Back to directory" link.
+const MATTER_PATH_RE =
+  /^\/matters\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(\/(overview|context|connect|flow))?$/i;
+
 function resolveBackLink(from: string | string[] | undefined): { href: string; label: string } {
   const raw = Array.isArray(from) ? from[0] : from;
-  if (raw && /^\/matters\/[0-9a-f-]+(\/[a-z0-9-]+)?$/i.test(raw)) {
+  if (raw && MATTER_PATH_RE.test(raw)) {
     return { href: raw, label: "Back to matter" };
   }
   return { href: "/lawyers", label: "Back to directory" };

--- a/app/matters/[id]/overview/page.tsx
+++ b/app/matters/[id]/overview/page.tsx
@@ -23,13 +23,13 @@ const ROLE_STYLES: Record<string, string> = {
 
 type TeamMember = MatterDetail["matter_team"][number];
 
-function TeamMemberCard({ member }: { member: TeamMember }) {
+function TeamMemberCard({ member, matterId }: { member: TeamMember; matterId: string }) {
   const lawyer = member.lawyer;
   if (!lawyer) return null;
 
   return (
     <Link
-      href={`/lawyers/${lawyer.id}`}
+      href={`/lawyers/${lawyer.id}?from=${encodeURIComponent(`/matters/${matterId}/overview`)}`}
       className="flex items-center gap-3 p-4 bg-white border border-brand-grey rounded-xl hover:border-brand-purple hover:shadow-sm transition-all group"
     >
       <div className="w-10 h-10 rounded-full bg-brand-purple/10 flex items-center justify-center flex-shrink-0">
@@ -163,7 +163,7 @@ export default async function MatterOverviewPage({
         </h2>
         <div className="space-y-2">
           {matter.matter_team.map((member) => (
-            <TeamMemberCard key={member.id} member={member} />
+            <TeamMemberCard key={member.id} member={member} matterId={matter.id} />
           ))}
         </div>
       </section>


### PR DESCRIPTION
## Summary
- \`app/matters/[id]/overview/page.tsx\`: team member card link now passes \`?from=/matters/[id]/overview\` (URL-encoded) to the lawyer profile.
- \`app/lawyers/[id]/page.tsx\`: reads \`searchParams.from\` and renders a context-aware back link. Strict regex sanitisation — only paths matching \`^/matters/<uuid>(/<segment>)?$\` are accepted; everything else falls through to the default "Back to directory" → \`/lawyers\` (prevents open-redirect).
- \`LawyerCard\` (firm directory) is intentionally unchanged — its default fallback "Back to directory" is correct.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] From a matter overview, click a team member → profile shows "Back to matter"; click → returns to that matter
- [ ] From the firm directory, click a lawyer → profile shows "Back to directory"; click → returns to /lawyers
- [ ] Visit \`/lawyers/<id>?from=https://evil.com\` → falls back to "Back to directory" (rejected by regex)
- [ ] Visit \`/lawyers/<id>?from=/admin\` → falls back to "Back to directory" (rejected — only matter paths allowed)

Closes #84