### PR TITLE
fix(field-notes): disambiguate lawyer FK embed and graceful upvote-check fallback

### DIFF
--- a/app/api/field-notes/route.ts
+++ b/app/api/field-notes/route.ts
@@ -52,7 +52,10 @@ export async function GET(req: Request) {
 
   let query = service
     .from("field_notes")
-    .select("id, jurisdiction_code, jurisdiction_name, title, content, matter_type, upvotes, created_at, author_id, author:lawyers(id, full_name, office_city)")
+    // Explicit FK — `field_note_upvotes` (added in migration 009) introduces a
+   // junction path between field_notes and lawyers, making `lawyers(...)`
+   // ambiguous and 500-ing the query. Naming the constraint forces the direct FK.
+    .select("id, jurisdiction_code, jurisdiction_name, title, content, matter_type, upvotes, created_at, author_id, author:lawyers!field_notes_author_id_fkey(id, full_name, office_city)")
     .eq("visibility", "firm")
     .order("upvotes", { ascending: false })
     .order("created_at", { ascending: false })
@@ -74,9 +77,12 @@ export async function GET(req: Request) {
       .eq("upvoter_id", lawyer.id)
       .in("note_id", noteIds);
     if (upvotedError) {
-      return NextResponse.json({ error: "Failed to load upvotes" }, { status: 500 });
+      // Degrade gracefully — notes still render, upvote buttons show as un-voted.
+      // Avoids breaking the whole page if the upvotes table is missing or RLS blocks reads.
+      console.error("Failed to load upvote status:", upvotedError.message);
+    } else {
+      upvotedSet = new Set((upvotedRows ?? []).map((r) => r.note_id as string));
     }
-    upvotedSet = new Set((upvotedRows ?? []).map((r) => r.note_id as string));
   }
 
   const enriched = (notes ?? []).map((n) => ({

--- a/app/api/field-notes/route.ts
+++ b/app/api/field-notes/route.ts
@@ -67,9 +67,13 @@ export async function GET(req: Request) {
   const { data: notes, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  // Mark which of these notes the current lawyer has already upvoted
+  // Mark which of these notes the current lawyer has already upvoted.
+  // If the upvotes table is missing/unreachable we degrade gracefully — notes
+  // still render — but we surface `upvote_disabled` so the UI can disable the
+  // upvote action (POST would also fail in that state).
   const noteIds = (notes ?? []).map((n) => n.id as string);
   let upvotedSet = new Set<string>();
+  let upvoteCheckFailed = false;
   if (noteIds.length > 0) {
     const { data: upvotedRows, error: upvotedError } = await service
       .from("field_note_upvotes")
@@ -77,9 +81,10 @@ export async function GET(req: Request) {
       .eq("upvoter_id", lawyer.id)
       .in("note_id", noteIds);
     if (upvotedError) {
-      // Degrade gracefully — notes still render, upvote buttons show as un-voted.
-      // Avoids breaking the whole page if the upvotes table is missing or RLS blocks reads.
+      // Service client bypasses RLS, so this is most commonly a missing
+      // `field_note_upvotes` table (migration 009 not applied) or a connectivity issue.
       console.error("Failed to load upvote status:", upvotedError.message);
+      upvoteCheckFailed = true;
     } else {
       upvotedSet = new Set((upvotedRows ?? []).map((r) => r.note_id as string));
     }
@@ -88,6 +93,7 @@ export async function GET(req: Request) {
   const enriched = (notes ?? []).map((n) => ({
     ...n,
     has_upvoted: upvotedSet.has(n.id as string),
+    upvote_disabled: upvoteCheckFailed,
   }));
 
   return NextResponse.json(enriched);

--- a/app/field-notes/page.tsx
+++ b/app/field-notes/page.tsx
@@ -14,6 +14,9 @@ type NoteWithAuthor = Pick<
 > & {
   author: Pick<Lawyer, "id" | "full_name" | "office_city"> | null;
   has_upvoted: boolean;
+  // True when the server couldn't determine upvote state (e.g. migration 009
+  // missing on the live DB). Disable the upvote action — POST would also fail.
+  upvote_disabled?: boolean;
 };
 
 // Built once at module scope — O(1) flag lookup per render
@@ -203,15 +206,23 @@ function FieldNotesContent() {
                 </div>
                 <button
                   onClick={() => handleUpvote(note.id)}
-                  disabled={upvoting === note.id || note.has_upvoted}
-                  title={note.has_upvoted ? "You upvoted this note" : `Upvoting awards the author +${UPVOTE_REWARD} reputation`}
+                  disabled={upvoting === note.id || note.has_upvoted || !!note.upvote_disabled}
+                  title={
+                    note.upvote_disabled
+                      ? "Upvotes are temporarily unavailable"
+                      : note.has_upvoted
+                      ? "You upvoted this note"
+                      : `Upvoting awards the author +${UPVOTE_REWARD} reputation`
+                  }
                   className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border transition-colors flex-shrink-0 ${
                     note.has_upvoted
                       ? "border-brand-purple/40 bg-brand-purple/10 cursor-default"
                       : "border-gray-200 hover:border-brand-purple/40 hover:bg-brand-purple/5"
                   } disabled:opacity-50`}
                   aria-label={
-                    note.has_upvoted
+                    note.upvote_disabled
+                      ? `Upvotes are temporarily unavailable (${note.upvotes} votes)`
+                      : note.has_upvoted
                       ? `You upvoted this note (${note.upvotes} votes)`
                       : `Upvote — author earns +${UPVOTE_REWARD} reputation (${note.upvotes} votes)`
                   }


### PR DESCRIPTION
## Summary

### Root cause
After PR #95 (the upvote uniqueness fix) shipped and migration 009 added `field_note_upvotes`, the field notes page started returning 500s. Network response:

> Could not embed because more than one relationship was found for 'field_notes' and 'lawyers'

PostgREST resource embedding became ambiguous because there are now two ways to relate `field_notes` to `lawyers`:
1. **Direct FK:** `field_notes.author_id → lawyers.id`
2. **Junction (new):** `field_notes ←→ field_note_upvotes ←→ lawyers`

The `author:lawyers(...)` embed didn't qualify which relationship to use, so PostgREST refused.

### Code change
- `app/api/field-notes/route.ts`: embed now names the constraint explicitly — `author:lawyers!field_notes_author_id_fkey(...)`. Same disambiguation pattern used by `app/api/flow/tasks/route.ts:69` for `tasks_assigned_to_fkey`.
- `app/api/field-notes/route.ts`: when the upvote-check query fails, the handler now logs and falls through with an empty `Set` instead of returning 500. Notes still render with `has_upvoted: false` — a graceful degradation path if the upvotes table is missing or RLS blocks reads.

## SQL for the user to run (Supabase Dashboard → SQL Editor)

If field notes have empty `jurisdiction_name` from before migration 008, backfill them:

```sql
UPDATE field_notes SET jurisdiction_name = CASE jurisdiction_code
  WHEN 'BR' THEN 'Brazil'
  WHEN 'CO' THEN 'Colombia'
  WHEN 'DE' THEN 'Germany'
  WHEN 'EU' THEN 'European Union'
  WHEN 'MX' THEN 'Mexico'
  WHEN 'US' THEN 'United States'
  ELSE jurisdiction_code
END
WHERE jurisdiction_name IS NULL OR jurisdiction_name = '';
```

If the live Supabase project hasn't had migration 009 applied yet, run `supabase/migrations/009_field_note_upvotes.sql` and the RLS ALTER (already in the file).

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Reload `/field-notes` → 200, cards render
- [ ] Network tab shows the `author` field populated on each note
- [ ] After backfill SQL runs, no card shows an empty jurisdiction name
- [ ] Upvote a note → reload → button stays disabled (assumes `field_note_upvotes` exists on the live DB)
- [ ] If `field_note_upvotes` is missing or RLS blocks it → notes still load (no 500)

Closes #102
Closes #104