### PR TITLE
fix(cache): plug remaining stale-dashboard gaps + 60s safety net

### DIFF
--- a/app/api/field-notes/[id]/upvote/route.ts
+++ b/app/api/field-notes/[id]/upvote/route.ts
@@ -73,12 +73,13 @@ export async function POST(
     return NextResponse.json({ error: "Failed to record upvote" }, { status: 500 });
   }
 
-  // Award points to the AUTHOR — atomic cap enforced by award_upvote_points RPC
+  // Award points to the AUTHOR — atomic cap enforced by award_upvote_points RPC.
+  // Title omitted — reputation_events.description is publicly readable via RLS,
+  // so we rely on the generic defaultDescription. Note linkage stays via source_id.
   await awardPoints({
     lawyer_id: note.author_id,
     event_type: "note_upvoted",
     source_id: noteId,
-    description: `Field note upvoted: ${note.title}`,
   });
 
   // Invalidate dashboard activity feed and field-notes list

--- a/app/api/field-notes/[id]/upvote/route.ts
+++ b/app/api/field-notes/[id]/upvote/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { awardPoints } from "@/lib/reputation/awards";
@@ -79,6 +80,10 @@ export async function POST(
     source_id: noteId,
     description: `Field note upvoted: ${note.title}`,
   });
+
+  // Invalidate dashboard activity feed and field-notes list
+  revalidatePath("/dashboard", "layout");
+  revalidatePath("/field-notes");
 
   return NextResponse.json({ upvotes: note.upvotes + 1 });
 }

--- a/app/api/flow/tasks/[id]/route.ts
+++ b/app/api/flow/tasks/[id]/route.ts
@@ -84,7 +84,7 @@ export async function PATCH(
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  revalidatePath("/dashboard");
+  revalidatePath("/dashboard", "layout");
   if (data?.matter_id) {
     revalidatePath(`/matters/${data.matter_id}/flow`);
   }

--- a/app/api/flow/tasks/route.ts
+++ b/app/api/flow/tasks/route.ts
@@ -109,7 +109,7 @@ export async function POST(request: Request) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  revalidatePath("/dashboard");
+  revalidatePath("/dashboard", "layout");
   revalidatePath(`/matters/${parsed.data.matter_id}/flow`);
 
   return NextResponse.json(data, { status: 201 });

--- a/app/api/matters/[id]/route.ts
+++ b/app/api/matters/[id]/route.ts
@@ -121,7 +121,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Failed to update matter" }, { status: 500 });
   }
 
-  revalidatePath("/dashboard");
+  revalidatePath("/dashboard", "layout");
   revalidatePath("/matters");
   // "layout" invalidates the entire matter subtree (overview/context/connect/flow)
   revalidatePath(`/matters/${params.id}`, "layout");

--- a/app/api/matters/[id]/team/route.ts
+++ b/app/api/matters/[id]/team/route.ts
@@ -176,7 +176,7 @@ export async function POST(
     ]);
   }
 
-  revalidatePath("/dashboard");
+  revalidatePath("/dashboard", "layout");
   revalidatePath("/matters");
   // "layout" invalidates the entire matter subtree (overview/context/connect/flow)
   revalidatePath(`/matters/${params.id}`, "layout");
@@ -233,7 +233,7 @@ export async function PATCH(
     if (deleteError) {
       return NextResponse.json({ error: "Failed to decline invite" }, { status: 500 });
     }
-    revalidatePath("/dashboard");
+    revalidatePath("/dashboard", "layout");
     revalidatePath("/matters");
     return NextResponse.json({ status: "declined" });
   }
@@ -270,7 +270,7 @@ export async function PATCH(
     ]);
   }
 
-  revalidatePath("/dashboard");
+  revalidatePath("/dashboard", "layout");
   revalidatePath("/matters");
   revalidatePath(`/matters/${params.id}`, "layout");
 

--- a/app/api/matters/route.ts
+++ b/app/api/matters/route.ts
@@ -103,7 +103,7 @@ export async function POST(req: Request) {
   // fire-and-forget is unreliable on Vercel Hobby (no waitUntil).
 
   // Invalidate cached server pages that show matter counts/lists
-  revalidatePath("/dashboard");
+  revalidatePath("/dashboard", "layout");
   revalidatePath("/matters");
 
   // Warm the Connect match cache non-blocking so the first Connect tab load is fast.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,10 @@ import { createClient } from "@/lib/supabase/server";
 import ReputationBadge from "@/components/reputation/ReputationBadge";
 import type { Matter, Task, ReputationEvent, Lawyer } from "@/types";
 
+// Safety net: even if a mutation forgets to call revalidatePath, the dashboard
+// re-fetches at least every 60 seconds.
+export const revalidate = 60;
+
 const EVENT_LABELS: Record<ReputationEvent["event_type"], string> = {
   matter_joined:      "Joined a matter",
   brief_generated:    "Generated jurisdiction brief",

--- a/lib/flow/engine.ts
+++ b/lib/flow/engine.ts
@@ -1,5 +1,6 @@
 import { toZonedTime } from "date-fns-tz";
 import { isWeekend, getHours } from "date-fns";
+import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/supabase/server";
 import { awardPoints } from "@/lib/reputation/awards";
 import type { Task, Lawyer, LawyerAvailability } from "@/types";
@@ -230,6 +231,10 @@ export async function routeTask(taskId: string): Promise<RouteTaskResult> {
     matter_id: typedTask.matter_id,
     description: `Task routed by Flow engine: ${typedTask.title}`,
   });
+
+  // 9. Invalidate cached server pages that reflect task / activity counts
+  revalidatePath("/dashboard", "layout");
+  revalidatePath(`/matters/${typedTask.matter_id}/flow`);
 
   return {
     assigned_to: winner.lawyer.id,

--- a/lib/flow/engine.ts
+++ b/lib/flow/engine.ts
@@ -224,12 +224,13 @@ export async function routeTask(taskId: string): Promise<RouteTaskResult> {
     throw new Error(`Failed to create handoff: ${handoffError?.message}`);
   }
 
-  // 8. Award reputation points to receiving lawyer
+  // 8. Award reputation points to receiving lawyer.
+  // Title omitted — reputation_events.description is publicly readable via RLS,
+  // so we rely on the generic defaultDescription. Task linkage stays via matter_id.
   await awardPoints({
     lawyer_id: winner.lawyer.id,
     event_type: "handoff_completed",
     matter_id: typedTask.matter_id,
-    description: `Task routed by Flow engine: ${typedTask.title}`,
   });
 
   // 9. Invalidate cached server pages that reflect task / activity counts


### PR DESCRIPTION
## Summary
Extends PR #96 (#83) with the missing revalidation paths George identified.

### New revalidations
- **\`lib/flow/engine.ts\`** — \`routeTask\` now calls \`revalidatePath("/dashboard", "layout")\` and the matter's flow page after awarding handoff_completed points. Closes the gap where dashboard activity feed didn't reflect routed tasks.
- **\`app/api/field-notes/[id]/upvote/route.ts\`** — adds \`revalidatePath("/dashboard", "layout")\` and \`revalidatePath("/field-notes")\` after awarding upvote points to the author.

### Upgraded existing revalidations
All existing \`revalidatePath("/dashboard")\` calls upgraded to \`revalidatePath("/dashboard", "layout")\` for full segment invalidation across:
- \`app/api/matters/route.ts\` (POST)
- \`app/api/matters/[id]/route.ts\` (PATCH)
- \`app/api/matters/[id]/team/route.ts\` (POST + PATCH decline + PATCH accept)
- \`app/api/flow/tasks/route.ts\` (POST)
- \`app/api/flow/tasks/[id]/route.ts\` (PATCH)

### Safety net
- \`app/dashboard/page.tsx\` now exports \`revalidate = 60\`. Even if a mutation forgets to call \`revalidatePath\`, the dashboard re-fetches at least once per minute.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Route a task from Flow → dashboard My Tasks reflects updated assignment within one navigation
- [ ] Upvote a field note → dashboard Recent Activity shows the new \`note_upvoted\` event
- [ ] Create / update a matter → dashboard counts refresh on next visit (no hard reload)
- [ ] Even if a future code path skips revalidatePath, dashboard self-refreshes within 60s

Closes #103