### PR TITLE
fix(notifications): bell polling + accept/decline toasts + task-assignment surfacing

### DIFF
--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -3,11 +3,13 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Bell, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Bell, CheckCircle2, Loader2 } from "lucide-react";
 import { useCurrentLawyer, getInitials } from "@/lib/hooks/useCurrentLawyer";
 import type { PendingInvite, ActivityEvent } from "@/app/api/notifications/route";
 
 const STORAGE_KEY = "bell_last_seen";
+const POLL_INTERVAL_MS = 60_000;
 
 function relativeTime(date: string): string {
   const diff = Date.now() - new Date(date).getTime();
@@ -71,12 +73,19 @@ function InviteRow({
 }
 
 export default function TopBar() {
+  const router = useRouter();
   const lawyer = useCurrentLawyer();
   const [invites, setInvites] = useState<PendingInvite[]>([]);
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [bellOpen, setBellOpen] = useState(false);
   const [lastSeen, setLastSeen] = useState<number>(0);
+  const [toast, setToast] = useState<string | null>(null);
   const bellRef = useRef<HTMLDivElement>(null);
+
+  const showToast = useCallback((message: string) => {
+    setToast(message);
+    setTimeout(() => setToast(null), 3500);
+  }, []);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -95,8 +104,14 @@ export default function TopBar() {
     }
   }, []);
 
+  // Initial fetch + background polling so the bell stays fresh across sessions
+  // without requiring a hard reload (#98).
   useEffect(() => {
     void fetchNotifications();
+    const interval = setInterval(() => {
+      void fetchNotifications();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
   }, [fetchNotifications]);
 
   useEffect(() => {
@@ -126,6 +141,7 @@ export default function TopBar() {
   }
 
   async function handleRespond(matterId: string, action: "accept" | "decline") {
+    const matter = invites.find((i) => i.matter_id === matterId);
     const res = await fetch(`/api/matters/${matterId}/team`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -134,7 +150,15 @@ export default function TopBar() {
     if (res.ok) {
       // Remove invite from list and re-fetch events to pick up new rep event on accept
       setInvites((prev) => prev.filter((i) => i.matter_id !== matterId));
-      if (action === "accept") await fetchNotifications();
+      if (action === "accept") {
+        showToast(`You joined ${matter?.matter_title ?? "the matter"}`);
+        await fetchNotifications();
+        // Refresh server-rendered pages (matters list, dashboard) so new
+        // membership shows without a hard reload (#98).
+        router.refresh();
+      } else {
+        showToast("Invite declined");
+      }
     }
   }
 
@@ -144,7 +168,15 @@ export default function TopBar() {
   const hasContent = invites.length > 0 || events.length > 0;
 
   return (
-    <div className="h-14 flex items-center justify-end gap-3 px-6 border-b border-gray-100 bg-white flex-shrink-0">
+    <div className="relative h-14 flex items-center justify-end gap-3 px-6 border-b border-gray-100 bg-white flex-shrink-0">
+      {/* Toast — accept/decline confirmation */}
+      {toast && (
+        <div className="absolute top-3 right-6 z-50 flex items-center gap-2 px-3 py-2 bg-green-50 border border-green-200 rounded-lg shadow-sm">
+          <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
+          <span className="text-xs font-medium text-green-700">{toast}</span>
+        </div>
+      )}
+
       {/* Bell */}
       <div className="relative" ref={bellRef}>
         <button

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -79,12 +79,22 @@ export default function TopBar() {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [bellOpen, setBellOpen] = useState(false);
   const [lastSeen, setLastSeen] = useState<number>(0);
-  const [toast, setToast] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ message: string; variant: "success" | "error" } | null>(null);
   const bellRef = useRef<HTMLDivElement>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fetchInflightRef = useRef(false);
 
-  const showToast = useCallback((message: string) => {
-    setToast(message);
-    setTimeout(() => setToast(null), 3500);
+  const showToast = useCallback((message: string, variant: "success" | "error" = "success") => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    setToast({ message, variant });
+    toastTimerRef.current = setTimeout(() => setToast(null), 3500);
+  }, []);
+
+  // Clear any pending toast timer on unmount to avoid setting state after unmount
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
   }, []);
 
   useEffect(() => {
@@ -96,11 +106,20 @@ export default function TopBar() {
   }, []);
 
   const fetchNotifications = useCallback(async () => {
-    const res = await fetch("/api/notifications");
-    if (res.ok) {
-      const data = await res.json();
-      setInvites(data.invites ?? []);
-      setEvents(data.events ?? []);
+    // Drop overlapping polls — slow request shouldn't be clobbered by a faster
+    // newer one returning out of order. `cache: "no-store"` prevents the browser
+    // from serving a cached response from a previous tick.
+    if (fetchInflightRef.current) return;
+    fetchInflightRef.current = true;
+    try {
+      const res = await fetch("/api/notifications", { cache: "no-store" });
+      if (res.ok) {
+        const data = await res.json();
+        setInvites(data.invites ?? []);
+        setEvents(data.events ?? []);
+      }
+    } finally {
+      fetchInflightRef.current = false;
     }
   }, []);
 
@@ -142,23 +161,39 @@ export default function TopBar() {
 
   async function handleRespond(matterId: string, action: "accept" | "decline") {
     const matter = invites.find((i) => i.matter_id === matterId);
-    const res = await fetch(`/api/matters/${matterId}/team`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action }),
-    });
-    if (res.ok) {
-      // Remove invite from list and re-fetch events to pick up new rep event on accept
-      setInvites((prev) => prev.filter((i) => i.matter_id !== matterId));
-      if (action === "accept") {
-        showToast(`You joined ${matter?.matter_title ?? "the matter"}`);
-        await fetchNotifications();
-        // Refresh server-rendered pages (matters list, dashboard) so new
-        // membership shows without a hard reload (#98).
-        router.refresh();
-      } else {
-        showToast("Invite declined");
+    let res: Response;
+    try {
+      res = await fetch(`/api/matters/${matterId}/team`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+    } catch {
+      showToast("Could not reach the server", "error");
+      return;
+    }
+    if (!res.ok) {
+      const fallback = action === "accept" ? "Couldn't accept invite" : "Couldn't decline invite";
+      let message = fallback;
+      try {
+        const body = await res.json();
+        if (typeof body?.error === "string") message = body.error;
+      } catch {
+        // ignore — keep fallback message
       }
+      showToast(message, "error");
+      return;
+    }
+    // Remove invite from list and re-fetch events to pick up new rep event on accept
+    setInvites((prev) => prev.filter((i) => i.matter_id !== matterId));
+    if (action === "accept") {
+      showToast(`You joined ${matter?.matter_title ?? "the matter"}`);
+      await fetchNotifications();
+      // Refresh server-rendered pages (matters list, dashboard) so new
+      // membership shows without a hard reload (#98).
+      router.refresh();
+    } else {
+      showToast("Invite declined");
     }
   }
 
@@ -169,11 +204,29 @@ export default function TopBar() {
 
   return (
     <div className="relative h-14 flex items-center justify-end gap-3 px-6 border-b border-gray-100 bg-white flex-shrink-0">
-      {/* Toast — accept/decline confirmation */}
+      {/* Toast — accept/decline confirmation. role=status + aria-live so SRs announce. */}
       {toast && (
-        <div className="absolute top-3 right-6 z-50 flex items-center gap-2 px-3 py-2 bg-green-50 border border-green-200 rounded-lg shadow-sm">
-          <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
-          <span className="text-xs font-medium text-green-700">{toast}</span>
+        <div
+          role="status"
+          aria-live="polite"
+          className={`absolute top-3 right-6 z-50 flex items-center gap-2 px-3 py-2 border rounded-lg shadow-sm ${
+            toast.variant === "error"
+              ? "bg-red-50 border-red-200"
+              : "bg-green-50 border-green-200"
+          }`}
+        >
+          <CheckCircle2
+            className={`w-4 h-4 flex-shrink-0 ${
+              toast.variant === "error" ? "text-red-600" : "text-green-600"
+            }`}
+          />
+          <span
+            className={`text-xs font-medium ${
+              toast.variant === "error" ? "text-red-700" : "text-green-700"
+            }`}
+          >
+            {toast.message}
+          </span>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Bundles #98 and #99 because the same TopBar polling change satisfies both: once the bell auto-refreshes, the existing \`handoff_completed\` reputation_event created by the Flow engine surfaces in the activity feed within one polling cycle.

### #98 — bell polling + toasts
- \`components/layout/TopBar.tsx\`: \`useEffect\` now sets a 60s interval that re-fetches \`/api/notifications\`; cleared on unmount
- Local toast state + small green confirmation card rendered top-right when an invite is responded to
- Accept → toast \`"You joined <Matter Title>"\` + \`router.refresh()\` so server-rendered matters list / dashboard reflect the new membership without a hard reload
- Decline → toast \`"Invite declined"\`

### #99 — task assignment notifications
The Flow engine already inserts a \`handoff_completed\` reputation_event after routing. The previously-stale bell never showed it; with #98's polling in place, the assignee sees it within ≤60s. The notifications API joins \`matters(title)\` so the bell row shows: \`"Received a task handoff" — <Matter Title>\`. Task title intentionally omitted (privacy — \`reputation_events.description\` is publicly readable).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Two browsers (Marcus + Isabella alias). From Marcus: invite Isabella. Isabella's bell badge increments within 60s without refresh.
- [ ] Isabella clicks accept → green toast "You joined …", invite disappears, matters list updates without hard reload.
- [ ] Isabella declines a different invite → grey/green toast "Invite declined".
- [ ] From Marcus: route a task to Isabella via Flow. Within 60s, Isabella's bell shows \`"Received a task handoff" — <matter title>\`.

Closes #98
Closes #99