### PR TITLE
feat(field-notes): clickable card opens detail modal

### DIFF
--- a/app/field-notes/page.tsx
+++ b/app/field-notes/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Loader2, ChevronUp, Plus, Search } from "lucide-react";
+import { Loader2, ChevronUp, Plus, Search, X } from "lucide-react";
 import Link from "next/link";
 import type { FieldNote, Lawyer } from "@/types";
 import { JURISDICTIONS as ALL_JURISDICTIONS } from "@/lib/jurisdictions";
@@ -62,6 +62,20 @@ function FieldNotesContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [upvoting, setUpvoting] = useState<string | null>(null);
+  // Track by id (not the full object) so the modal stays in sync when the
+  // parent notes array updates after an upvote.
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const selectedNote = selectedNoteId ? notes.find((n) => n.id === selectedNoteId) ?? null : null;
+
+  // Close modal on Escape
+  useEffect(() => {
+    if (!selectedNoteId) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setSelectedNoteId(null);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [selectedNoteId]);
 
   const jurisdiction = searchParams.get("jurisdiction") || "";
   const q = searchParams.get("q") || "";
@@ -184,7 +198,17 @@ function FieldNotesContent() {
           {notes.map((note) => (
             <div
               key={note.id}
-              className="bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3"
+              role="button"
+              tabIndex={0}
+              onClick={() => setSelectedNoteId(note.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setSelectedNoteId(note.id);
+                }
+              }}
+              aria-label={`Open note: ${note.title}`}
+              className="bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3 cursor-pointer hover:border-brand-purple/40 hover:shadow-sm transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"
             >
               {/* Top row */}
               <div className="flex items-start justify-between gap-3">
@@ -205,7 +229,14 @@ function FieldNotesContent() {
                   </h3>
                 </div>
                 <button
-                  onClick={() => handleUpvote(note.id)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleUpvote(note.id);
+                  }}
+                  onKeyDown={(e) => {
+                    // Stop Enter/Space from bubbling and triggering the card's open handler
+                    if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+                  }}
                   disabled={upvoting === note.id || note.has_upvoted || !!note.upvote_disabled}
                   title={
                     note.upvote_disabled
@@ -248,6 +279,91 @@ function FieldNotesContent() {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Detail modal */}
+      {selectedNote && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="note-modal-title"
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40"
+          onClick={() => setSelectedNoteId(null)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="relative bg-white rounded-xl shadow-xl max-w-2xl w-full max-h-[85vh] flex flex-col"
+          >
+            {/* Header */}
+            <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-3 border-b border-gray-100">
+              <div className="flex-1 min-w-0">
+                <span
+                  className={`inline-flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full ${
+                    JURISDICTION_COLORS[selectedNote.jurisdiction_code] ?? "bg-gray-100 text-gray-600"
+                  }`}
+                >
+                  <span aria-hidden="true">{getFlag(selectedNote.jurisdiction_code)}</span>
+                  <span>{selectedNote.jurisdiction_code}</span>
+                  {selectedNote.jurisdiction_name && (
+                    <span className="opacity-75">· {selectedNote.jurisdiction_name}</span>
+                  )}
+                </span>
+                <h2 id="note-modal-title" className="font-semibold text-gray-900 text-base mt-2 leading-snug">
+                  {selectedNote.title}
+                </h2>
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <button
+                  onClick={() => void handleUpvote(selectedNote.id)}
+                  disabled={upvoting === selectedNote.id || selectedNote.has_upvoted || !!selectedNote.upvote_disabled}
+                  title={
+                    selectedNote.upvote_disabled
+                      ? "Upvotes are temporarily unavailable"
+                      : selectedNote.has_upvoted
+                      ? "You upvoted this note"
+                      : `Upvoting awards the author +${UPVOTE_REWARD} reputation`
+                  }
+                  className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border transition-colors ${
+                    selectedNote.has_upvoted
+                      ? "border-brand-purple/40 bg-brand-purple/10 cursor-default"
+                      : "border-gray-200 hover:border-brand-purple/40 hover:bg-brand-purple/5"
+                  } disabled:opacity-50`}
+                >
+                  {upvoting === selectedNote.id ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin text-brand-purple" />
+                  ) : (
+                    <ChevronUp
+                      className={`w-3.5 h-3.5 text-brand-purple ${selectedNote.has_upvoted ? "fill-current" : ""}`}
+                    />
+                  )}
+                  <span className="text-[11px] font-semibold text-brand-purple">{selectedNote.upvotes}</span>
+                </button>
+                <button
+                  onClick={() => setSelectedNoteId(null)}
+                  aria-label="Close"
+                  className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Body */}
+            <div className="px-6 py-4 overflow-y-auto">
+              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-line">
+                {selectedNote.content}
+              </p>
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between text-[11px] text-gray-400 px-6 py-3 border-t border-gray-100">
+              <span>
+                {selectedNote.author?.full_name ?? "Unknown"} · {selectedNote.author?.office_city}
+              </span>
+              <span>{relativeTime(selectedNote.created_at)}</span>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/app/field-notes/page.tsx
+++ b/app/field-notes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, Suspense } from "react";
+import { useEffect, useState, useCallback, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2, ChevronUp, Plus, Search, X } from "lucide-react";
 import Link from "next/link";
@@ -66,16 +66,27 @@ function FieldNotesContent() {
   // parent notes array updates after an upvote.
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const selectedNote = selectedNoteId ? notes.find((n) => n.id === selectedNoteId) ?? null : null;
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
 
-  // Close modal on Escape
+  // Close modal on Escape and focus the close button when it opens.
   useEffect(() => {
     if (!selectedNoteId) return;
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") setSelectedNoteId(null);
     }
     document.addEventListener("keydown", onKey);
+    // Move focus into the dialog so screen readers announce it and Tab moves within
+    closeButtonRef.current?.focus();
     return () => document.removeEventListener("keydown", onKey);
   }, [selectedNoteId]);
+
+  // If the selected note disappears from the list (refetch / filter change),
+  // clear the selection so the modal closes cleanly and doesn't reopen later.
+  useEffect(() => {
+    if (selectedNoteId && !notes.some((n) => n.id === selectedNoteId)) {
+      setSelectedNoteId(null);
+    }
+  }, [notes, selectedNoteId]);
 
   const jurisdiction = searchParams.get("jurisdiction") || "";
   const q = searchParams.get("q") || "";
@@ -196,19 +207,13 @@ function FieldNotesContent() {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {notes.map((note) => (
+            // Outer card is a non-interactive container. The title `<button>`
+            // below carries an `inset-0` overlay span so the whole card area
+            // is clickable, while the upvote button (with `relative z-10`)
+            // stays interactive without nested-interactive HTML.
             <div
               key={note.id}
-              role="button"
-              tabIndex={0}
-              onClick={() => setSelectedNoteId(note.id)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  setSelectedNoteId(note.id);
-                }
-              }}
-              aria-label={`Open note: ${note.title}`}
-              className="bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3 cursor-pointer hover:border-brand-purple/40 hover:shadow-sm transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"
+              className="relative bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3 hover:border-brand-purple/40 hover:shadow-sm transition-shadow"
             >
               {/* Top row */}
               <div className="flex items-start justify-between gap-3">
@@ -225,18 +230,21 @@ function FieldNotesContent() {
                     )}
                   </span>
                   <h3 className="font-semibold text-gray-900 text-sm mt-2 leading-snug">
-                    {note.title}
+                    <button
+                      type="button"
+                      onClick={() => setSelectedNoteId(note.id)}
+                      className="text-left rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"
+                      aria-label={`Open note: ${note.title}`}
+                    >
+                      {/* Full-card click overlay — covers the entire card; upvote button
+                          uses `relative z-10` to remain on top and intercept its clicks. */}
+                      <span className="absolute inset-0" aria-hidden="true" />
+                      {note.title}
+                    </button>
                   </h3>
                 </div>
                 <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void handleUpvote(note.id);
-                  }}
-                  onKeyDown={(e) => {
-                    // Stop Enter/Space from bubbling and triggering the card's open handler
-                    if (e.key === "Enter" || e.key === " ") e.stopPropagation();
-                  }}
+                  onClick={() => void handleUpvote(note.id)}
                   disabled={upvoting === note.id || note.has_upvoted || !!note.upvote_disabled}
                   title={
                     note.upvote_disabled
@@ -245,7 +253,7 @@ function FieldNotesContent() {
                       ? "You upvoted this note"
                       : `Upvoting awards the author +${UPVOTE_REWARD} reputation`
                   }
-                  className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border transition-colors flex-shrink-0 ${
+                  className={`relative z-10 flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border transition-colors flex-shrink-0 ${
                     note.has_upvoted
                       ? "border-brand-purple/40 bg-brand-purple/10 cursor-default"
                       : "border-gray-200 hover:border-brand-purple/40 hover:bg-brand-purple/5"
@@ -324,6 +332,13 @@ function FieldNotesContent() {
                       ? "You upvoted this note"
                       : `Upvoting awards the author +${UPVOTE_REWARD} reputation`
                   }
+                  aria-label={
+                    selectedNote.upvote_disabled
+                      ? `Upvotes are temporarily unavailable (${selectedNote.upvotes} votes)`
+                      : selectedNote.has_upvoted
+                      ? `You upvoted this note (${selectedNote.upvotes} votes)`
+                      : `Upvote — author earns +${UPVOTE_REWARD} reputation (${selectedNote.upvotes} votes)`
+                  }
                   className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg border transition-colors ${
                     selectedNote.has_upvoted
                       ? "border-brand-purple/40 bg-brand-purple/10 cursor-default"
@@ -340,6 +355,7 @@ function FieldNotesContent() {
                   <span className="text-[11px] font-semibold text-brand-purple">{selectedNote.upvotes}</span>
                 </button>
                 <button
+                  ref={closeButtonRef}
                   onClick={() => setSelectedNoteId(null)}
                   aria-label="Close"
                   className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"


### PR DESCRIPTION
## Summary
- \`app/field-notes/page.tsx\`: each card now \`role="button"\` with click + keyboard handlers that set \`selectedNoteId\`. Modal renders the full content (no \`line-clamp\`), with the same upvote button still functional inside.
- Stored as \`selectedNoteId\` (not the full object) so the modal stays in sync when the parent \`notes\` array updates after an upvote.
- Modal is dismissed by: backdrop click, close button, or Escape key (registered via a scoped \`useEffect\`).
- Upvote button \`stopPropagation\` on click + Enter/Space keydown so opening the modal isn't triggered when the user just wanted to upvote.
- Modal has \`role="dialog"\`, \`aria-modal\`, and \`aria-labelledby\` pointing to the title.
- No new dependency — pure Tailwind modal.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Click anywhere on a note card → modal opens with full content (no truncation)
- [ ] Tab to a card, hit Enter → modal opens
- [ ] Click the upvote button on the card → modal does NOT open; count increments; button disables
- [ ] Inside modal, click upvote → same behavior
- [ ] Close via X button, backdrop click, or Escape

Closes #101