### PR TITLE
fix(matters): date labels, manual status control, and auto-complete rollup

### DIFF
--- a/app/api/flow/tasks/[id]/route.ts
+++ b/app/api/flow/tasks/[id]/route.ts
@@ -86,28 +86,40 @@ export async function PATCH(
 
   // Auto-update matter status when task completion state changes
   if (data?.matter_id && parsed.data.status !== undefined) {
-    const { data: allTasks } = await service
+    const { data: allTasks, error: allTasksError } = await service
       .from("tasks")
       .select("status")
       .eq("matter_id", data.matter_id);
+
+    if (allTasksError) {
+      return NextResponse.json({ error: allTasksError.message }, { status: 500 });
+    }
 
     if (allTasks && allTasks.length > 0) {
       const allDone = allTasks.every((t) => t.status === "completed");
       const anyOpen = allTasks.some((t) => t.status !== "completed");
 
       if (allDone) {
-        await service
+        const { error: matterUpdateError } = await service
           .from("matters")
           .update({ status: "completed" })
           .eq("id", data.matter_id)
           .eq("status", "active");
+
+        if (matterUpdateError) {
+          return NextResponse.json({ error: matterUpdateError.message }, { status: 500 });
+        }
       } else if (anyOpen) {
         // Revert to active if a task is re-opened on a completed matter
-        await service
+        const { error: matterUpdateError } = await service
           .from("matters")
           .update({ status: "active" })
           .eq("id", data.matter_id)
           .eq("status", "completed");
+
+        if (matterUpdateError) {
+          return NextResponse.json({ error: matterUpdateError.message }, { status: 500 });
+        }
       }
     }
   }

--- a/app/api/flow/tasks/[id]/route.ts
+++ b/app/api/flow/tasks/[id]/route.ts
@@ -84,9 +84,38 @@ export async function PATCH(
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
+  // Auto-update matter status when task completion state changes
+  if (data?.matter_id && parsed.data.status !== undefined) {
+    const { data: allTasks } = await service
+      .from("tasks")
+      .select("status")
+      .eq("matter_id", data.matter_id);
+
+    if (allTasks && allTasks.length > 0) {
+      const allDone = allTasks.every((t) => t.status === "completed");
+      const anyOpen = allTasks.some((t) => t.status !== "completed");
+
+      if (allDone) {
+        await service
+          .from("matters")
+          .update({ status: "completed" })
+          .eq("id", data.matter_id)
+          .eq("status", "active");
+      } else if (anyOpen) {
+        // Revert to active if a task is re-opened on a completed matter
+        await service
+          .from("matters")
+          .update({ status: "active" })
+          .eq("id", data.matter_id)
+          .eq("status", "completed");
+      }
+    }
+  }
+
   revalidatePath("/dashboard", "layout");
+  revalidatePath("/matters");
   if (data?.matter_id) {
-    revalidatePath(`/matters/${data.matter_id}/flow`);
+    revalidatePath(`/matters/${data.matter_id}`, "layout");
   }
 
   return NextResponse.json(data);

--- a/app/matters/[id]/_components/MatterStatusSelect.tsx
+++ b/app/matters/[id]/_components/MatterStatusSelect.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+const STATUS_STYLES: Record<string, string> = {
+  active: "bg-green-50 text-green-700 border-green-200",
+  completed: "bg-blue-50 text-blue-700 border-blue-200",
+  archived: "bg-gray-100 text-gray-500 border-gray-200",
+};
+
+const STATUSES = ["active", "completed", "archived"] as const;
+type MatterStatus = typeof STATUSES[number];
+
+export default function MatterStatusSelect({
+  matterId,
+  initialStatus,
+}: {
+  matterId: string;
+  initialStatus: MatterStatus;
+}) {
+  const router = useRouter();
+  const [status, setStatus] = useState<MatterStatus>(initialStatus);
+  const [saving, setSaving] = useState(false);
+
+  async function handleChange(next: MatterStatus) {
+    if (next === status || saving) return;
+    const prev = status;
+    setStatus(next);
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/matters/${matterId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: next }),
+      });
+      if (!res.ok) {
+        setStatus(prev);
+      } else {
+        router.refresh();
+      }
+    } catch {
+      setStatus(prev);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <select
+        value={status}
+        onChange={(e) => handleChange(e.target.value as MatterStatus)}
+        disabled={saving}
+        aria-label="Matter status"
+        className={`text-[11px] font-medium pl-2 pr-6 py-0.5 rounded-full border appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-purple/40 disabled:opacity-60 ${
+          STATUS_STYLES[status] ?? STATUS_STYLES.active
+        }`}
+      >
+        {STATUSES.map((s) => (
+          <option key={s} value={s}>
+            {s.charAt(0).toUpperCase() + s.slice(1)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/app/matters/[id]/layout.tsx
+++ b/app/matters/[id]/layout.tsx
@@ -1,15 +1,10 @@
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Calendar } from "lucide-react";
+import { ArrowLeft, Calendar, Clock } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import MatterTabs from "./_components/MatterTabs";
+import MatterStatusSelect from "./_components/MatterStatusSelect";
 import { getMatterDetail } from "./_lib/getMatter";
-
-const STATUS_STYLES: Record<string, string> = {
-  active: "bg-green-50 text-green-700 border-green-200",
-  completed: "bg-blue-50 text-blue-700 border-blue-200",
-  archived: "bg-gray-100 text-gray-500 border-gray-200",
-};
 
 function formatDate(iso: string) {
   return new Date(iso).toLocaleDateString("en-GB", {
@@ -50,26 +45,23 @@ export default async function MatterLayout({
         <div className="mb-4">
           <div className="flex items-center gap-3 mb-1">
             <h1 className="text-xl font-bold text-gray-900">{matter.title}</h1>
-            <span
-              className={`text-[11px] font-medium px-2 py-0.5 rounded-full border ${
-                STATUS_STYLES[matter.status] ?? STATUS_STYLES.active
-              }`}
-            >
-              {matter.status.charAt(0).toUpperCase() + matter.status.slice(1)}
-            </span>
+            <MatterStatusSelect matterId={matter.id} initialStatus={matter.status} />
           </div>
           <p className="text-sm text-gray-500">
             {matter.client_name}
             <span className="mx-2 text-gray-300">·</span>
             {matter.matter_type}
-            {matter.deadline && (
-              <>
-                <span className="mx-2 text-gray-300">·</span>
-                <span className="inline-flex items-center gap-1">
-                  <Calendar className="w-3.5 h-3.5" />
-                  Due {formatDate(matter.deadline)}
-                </span>
-              </>
+            <span className="mx-2 text-gray-300">·</span>
+            {matter.deadline ? (
+              <span className="inline-flex items-center gap-1">
+                <Calendar className="w-3.5 h-3.5" />
+                Due {formatDate(matter.deadline)}
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1">
+                <Clock className="w-3.5 h-3.5" />
+                Created {formatDate(matter.created_at)}
+              </span>
             )}
           </p>
         </div>

--- a/app/matters/_components/MattersDirectory.tsx
+++ b/app/matters/_components/MattersDirectory.tsx
@@ -106,7 +106,7 @@ function MatterCard({ matter }: { matter: MatterSummary }) {
         ) : (
           <span className="flex items-center gap-1">
             <Clock className="w-3 h-3" />
-            {formatDate(matter.created_at)}
+            Created {formatDate(matter.created_at)}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary

- **#111 — Date mismatch**: Matter tiles and the matter header now consistently show a labelled `Created …` date when no deadline is set (was showing an unlabelled timestamp or nothing)
- **#112 — Matter status control**: Replaced static status badge in the matter layout with an interactive dropdown (`MatterStatusSelect`) — lawyers can manually set Active / Completed / Archived; change is persisted via `PATCH /api/matters/[id]` with optimistic update and `router.refresh()` so the layout re-renders automatically without a manual page reload
- **#112 — Auto-complete rollup**: After any task status update, the API now rolls up the parent matter's status — if all tasks are completed the matter auto-completes; if any task is re-opened on a completed matter it reverts to active

## Test plan

- [ ] Open a matter with no deadline — header and tile both show `Created <date>`
- [ ] Change matter status via the dropdown — dropdown updates immediately, page re-renders with new status without a manual refresh
- [ ] Select an invalid network state (DevTools → offline) — dropdown reverts to previous value on failure
- [ ] Mark all tasks on a matter as completed — matter status should auto-flip to Completed
- [ ] Re-open one task on a completed matter — matter status should revert to Active

🤖 Generated with [Claude Code](https://claude.ai/claude-code)